### PR TITLE
Fix nnodes estimation.

### DIFF
--- a/aiida_nanotech_empa/workflows/nanoribbon.py
+++ b/aiida_nanotech_empa/workflows/nanoribbon.py
@@ -383,9 +383,10 @@ class NanoribbonWorkChain(WorkChain):
             1 + int(nkpoints * 2.4 /
                     builder.code.computer.get_default_mpiprocs_per_machine()),
             int(5))
-        nnodes = (1 + int(
-            natoms * 0.2 /
-            builder.code.computer.get_default_mpiprocs_per_machine())) * npools
+        #nnodes = (1 + int(
+        #    natoms * 0.2 /
+        #    builder.code.computer.get_default_mpiprocs_per_machine())) * npools
+        nnodes = (1 + natoms/60) * npools
 
         builder.metadata.label = label
         builder.metadata.options = {


### PR DESCRIPTION
This is a temporary fix that let's correctly estimate the number
of nodes for the CSCS supercomputers. The issue here is different nodes
have more or less the same amount of RAM, so the number of CPUs
can't be used as a criterion to select the number of nodes.

Once the following issue is fixed: https://github.com/aiidateam/aiida-core/issues/4297,
we can implement a better mechanism to auto-select the number of nodes.