### PR TITLE
Add a modified lsf scheduler for ETHZ Euler machine

### DIFF
--- a/aiida_nanotech_empa/schedulers/lsf_ethz_euler.py
+++ b/aiida_nanotech_empa/schedulers/lsf_ethz_euler.py
@@ -1,0 +1,33 @@
+from aiida.plugins import SchedulerFactory
+
+LsfScheduler = SchedulerFactory("lsf")
+
+
+class ETHZEulerLsfScheduler(LsfScheduler):
+    """
+    The ETHZ Euler LSF scheduler requires memory and scratch space to be
+    reserved with the line 
+    #BSUB -R "rusage[mem=X,scratch=Y]"
+    where X and Y are specified in units of MB per cpu
+    """
+    def _get_submit_script_header(self, job_tmpl):
+        lsf_script_lines = super()._get_submit_script_header(
+            job_tmpl).splitlines()
+
+        physical_memory_kb = int(job_tmpl.max_memory_kb)
+        num_mpiprocs = job_tmpl.job_resource.get_tot_num_mpiprocs()
+        mem_per_proc_mb = physical_memory_kb // (1024 * num_mpiprocs)
+
+        new_lines = []
+        for line in lsf_script_lines:
+            if line.startswith("#BSUB -M"):
+                # Skip the BSUB -M line
+                continue
+            if not line.strip():
+                # Add the rusage line before the first empty line
+                new_lines.append(
+                    '#BSUB -R \"rusage[mem={},scratch={}]\"'.format(
+                        mem_per_proc_mb, 2 * mem_per_proc_mb))
+            new_lines.append(line)
+
+        return "\n".join(lsf_script_lines)

--- a/setup.json
+++ b/setup.json
@@ -26,6 +26,9 @@
             "nanotech_empa.gaussian.delta_scf = aiida_nanotech_empa.workflows.gaussian:GaussianDeltaScfWorkChain",
             "nanotech_empa.gaussian.natorb = aiida_nanotech_empa.workflows.gaussian:GaussianNatOrbWorkChain",
             "nanotech_empa.gaussian.spin = aiida_nanotech_empa.workflows.gaussian:GaussianSpinWorkChain"
+        ],
+        "aiida.schedulers": [
+            "lsf_ethz_euler = aiida_nanotech_empa.schedulers.lsf_ethz_euler:ETHZEulerLsfScheduler"
         ]
     },
     "include_package_data": true,


### PR DESCRIPTION
Hi,

The default LSF scheduler provided by aiida-core is not fully compatible with the ETHZ Euler cluster (even though it also uses the LSF scheduler).

Main difference is in memory allocation:

1) In the Euler cluster, memory needs to be allocated with the `#BSUB -R "rusage[mem=X,scratch=Y]"` directive, which at the moment is not set in the default LSF scheduler plugin, but it rather uses the `#BSUB -M X` line, which is ignored in Euler to my understanding. In principle the `rusage` line could just be added to the default lsf scheduler and most likely will work for other clusters as well but i can't be 100% sure.

2) More tedious is that the LSF Scheduler can be configured in many different ways. For exampe, one can define different default units to be used when specifying memory (e.g. [LSF_UNIT_FOR_LIMITS](https://www.ibm.com/support/knowledgecenter/en/SSWRJV_10.1.0/lsf_config_ref/lsf.conf.lsf_unit_for_limits.5.html)). The default LSF scheduler assumes that the memory limit units are in KB but ETHZ Euler assumes MB. 

For these reasons, I thought it makes sense to just make a custom scheduler just for ETHZ Euler.