### PR TITLE
PP parser more efficient; change default cube height up to 5 ang

### DIFF
--- a/aiida_nanotech_empa/parsers/pp_parser.py
+++ b/aiida_nanotech_empa/parsers/pp_parser.py
@@ -4,12 +4,14 @@ Register parsers via the "aiida.parsers" entry point in setup.json.
 """
 import numpy as np
 
-from aiida_nanotech_empa.utils.cube_utils import crop_cube, read_cube_file, write_cube_file
+from aiida_nanotech_empa.utils.cube_utils import crop_cube, read_cube_file
 
 from aiida import orm
 from aiida.plugins import ParserFactory
 
 BasePpParser = ParserFactory('quantumespresso.pp')
+
+ang_2_bohr = 1.889725989
 
 
 class PpParser(BasePpParser):
@@ -24,66 +26,24 @@ class PpParser(BasePpParser):
                                                 cell,
                                                 origin,
                                                 x_crop=None,
-                                                y_crop=3.5,
-                                                z_crop=6.2)
+                                                y_crop=1.8,
+                                                z_crop=(3.1, 5.1))
         # NB! No point in clipping if the file is not compressed!
         #clip_data(new_data, absmin=1e-8)
-        cropped_data_file_str = write_cube_file(numbers, new_pos, new_cell,
-                                                new_data)
-        return self.parse_gaussian2(cropped_data_file_str)
 
-    def parse_gaussian2(self, data_file_str):  # pylint: disable=too-many-locals
-        """Parse Gaussian Cube formatted output.
-        :param data_file_str: the data file read in as a single string
-        """
-        lines = data_file_str.splitlines()
-
-        atoms_line = lines[2].split()
-        natoms = int(atoms_line[0])  # The number of atoms listed in the file
-
-        header = lines[:6 +
-                       natoms]  # Header of the file: comments, the voxel, and the number of atoms and datapoints
-        data_lines = lines[
-            6 + natoms:]  # The actual data: atoms and volumetric data
-
-        # Parse the declared dimensions of the volumetric data
-        x_line = header[3].split()
-        xdim = int(x_line[0])
-        y_line = header[4].split()
-        ydim = int(y_line[0])
-        z_line = header[5].split()
-        zdim = int(z_line[0])
-
-        # Get the vectors describing the basis voxel
-        voxel_array = np.array([[x_line[1], x_line[2], x_line[3]],
-                                [y_line[1], y_line[2], y_line[3]],
-                                [z_line[1], z_line[2], z_line[3]]],
-                               dtype=np.float64)
-        atomic_numbers = np.empty(natoms, int)
-        coordinates = np.empty((natoms, 3))
-        for i in range(natoms):
-            line = header[6 + i].split()
-            atomic_numbers[i] = int(line[0])
-            coordinates[i] = [float(s) for s in line[2:]]
-
-        # Get the volumetric data
-        data_array = np.empty(xdim * ydim * zdim, dtype=float)
-        cursor = 0
-        for line in data_lines:
-            ls = line.split()
-            data_array[cursor:cursor + len(ls)] = ls
-            cursor += len(ls)
-        data_array = data_array.reshape((xdim, ydim, zdim))
-
+        # Create the arraydata object
         coordinates_units = 'bohr'
+        new_pos_au = new_pos * ang_2_bohr
+        voxel_array = new_cell * ang_2_bohr / np.atleast_2d(new_data.shape).T
+
         data_units = self.units_dict[self.output_parameters['plot_num']]
 
         arraydata = orm.ArrayData()
         arraydata.set_array('voxel', voxel_array)
-        arraydata.set_array('data', data_array)
+        arraydata.set_array('data', new_data)
         arraydata.set_array('data_units', np.array(data_units))
         arraydata.set_array('coordinates_units', np.array(coordinates_units))
-        arraydata.set_array('coordinates', coordinates)
-        arraydata.set_array('atomic_numbers', atomic_numbers)
+        arraydata.set_array('coordinates', new_pos_au)
+        arraydata.set_array('atomic_numbers', numbers)
 
         return arraydata


### PR DESCRIPTION
The PP parser had a redundant file writing and reading part. Now it's more efficient.

Additionally, we need in some cases the exported cube files to go up to 5 angstrom.