### PR TITLE
revert pp parser cube crop back to h=3, as QE becomes noisy further away

### DIFF
--- a/aiida_nanotech_empa/parsers/pp_parser.py
+++ b/aiida_nanotech_empa/parsers/pp_parser.py
@@ -27,7 +27,7 @@ class PpParser(BasePpParser):
                                                 origin,
                                                 x_crop=None,
                                                 y_crop=1.8,
-                                                z_crop=(3.1, 5.1))
+                                                z_crop=(3.1, 3.1))
         # NB! No point in clipping if the file is not compressed!
         #clip_data(new_data, absmin=1e-8)
 


### PR DESCRIPTION
As the exported cube files from QE become noisy at distances away from atoms (see image below), it doesn't make sense to keep the extended volume.

![image](https://user-images.githubusercontent.com/8721264/114045236-2cd40a00-9888-11eb-96ee-01b4dd035500.png)
