### PR TITLE
Update GW GPW protocol

### DIFF
--- a/aiida_nanotech_empa/workflows/cp2k/adsorbed_gw_ic_workchain.py
+++ b/aiida_nanotech_empa/workflows/cp2k/adsorbed_gw_ic_workchain.py
@@ -134,7 +134,7 @@ class Cp2kAdsorbedGwIcWorkChain(WorkChain):
                    help="Substrate type, determines the image charge plane.")
         spec.input("protocol",
                    valid_type=Str,
-                   default=lambda: Str('gapw_std'),
+                   default=lambda: Str('gpw_std'),
                    required=False,
                    help="Protocol supported by the GW workchain.")
         spec.input("multiplicity",

--- a/aiida_nanotech_empa/workflows/cp2k/adsorbed_gw_ic_workchain.py
+++ b/aiida_nanotech_empa/workflows/cp2k/adsorbed_gw_ic_workchain.py
@@ -51,12 +51,21 @@ def analyze_structure(structure, substrate, mag_per_site, ads_h=None):
         # Adsorption height is defined from the geometrical center of the molecule
         surf_z = np.mean(mol_atoms.positions[:, 2]) - ads_h.value
 
+    else:
+        # If you manually specify adsorption height, it will override the
+        # height extracted from the geometry
+        if ads_h is not None:
+            surf_z = np.mean(mol_atoms.positions[:, 2]) - ads_h.value
+
     imag_plane_z = surf_z + IC_PLANE_HEIGHTS[substrate.value]
 
     mps = []
     if list(mag_per_site):
+        mol_at_tuples = [(e, *np.round(p, 2)) for e, p in zip(
+            mol_atoms.get_chemical_symbols(), mol_atoms.positions)]
         mps = [
-            m for at, m in zip(ase_geo, list(mag_per_site)) if at in mol_atoms
+            m for at, m in zip(ase_geo, list(mag_per_site))
+            if (at.symbol, *np.round(at.position, 2)) in mol_at_tuples
         ]
 
     return {

--- a/aiida_nanotech_empa/workflows/cp2k/data/atomic_kinds.yml
+++ b/aiida_nanotech_empa/workflows/cp2k/data/atomic_kinds.yml
@@ -143,16 +143,16 @@ basis_set:
 # Basis sets for the GW workchain
 # -------------------------------------------------------------
 gpw_std_gw_basis_set:
-  H:  aug-cc-pVDZ-GTH
+  H:  aug-DZVP-GTH-up-up-up-up
   B:  K-aug-DZVP-GTH-3
-  C:  aug-cc-pVDZ-GTH
+  C:  aug-DZVP-GTH-up-up-up-up
   N:  aug-DZVP-GTH
   O:  aug-DZVP-GTH
 
 gpw_std_gw_basis_set_aux:
-  H:  aug-cc-pVDZ-RIFIT
+  H:  RI_aug_DZ
   B:  K-RI_aug_DZ
-  C:  aug-cc-pVDZ-RIFIT
+  C:  RI_aug_DZ
   N:  RI_aug_DZ
   O:  RI_DZVP-own  
 

--- a/aiida_nanotech_empa/workflows/cp2k/protocols/gw_protocols.yml
+++ b/aiida_nanotech_empa/workflows/cp2k/protocols/gw_protocols.yml
@@ -67,6 +67,7 @@ gpw_std_scf_step:
       POTENTIAL_FILE_NAME: POTENTIAL
       UKS: '.FALSE.'
       MULTIPLICITY: '0'
+      SORT_BASIS: 'EXP'
       MGRID:
         CUTOFF: '600'
         REL_CUTOFF: '50'
@@ -107,6 +108,7 @@ gpw_std_gw_step:
       POTENTIAL_FILE_NAME: POTENTIAL
       UKS: '.FALSE.'
       MULTIPLICITY: '0'
+      SORT_BASIS: 'EXP'
       MGRID:
         CUTOFF: '600'
         REL_CUTOFF: '50'
@@ -156,6 +158,7 @@ gpw_std_ic_step:
       POTENTIAL_FILE_NAME: POTENTIAL
       UKS: '.FALSE.'
       MULTIPLICITY: '0'
+      SORT_BASIS: 'EXP'
       MGRID:
         CUTOFF: '600'
         REL_CUTOFF: '50'

--- a/aiida_nanotech_empa/workflows/cp2k/protocols/gw_protocols.yml
+++ b/aiida_nanotech_empa/workflows/cp2k/protocols/gw_protocols.yml
@@ -127,7 +127,7 @@ gpw_std_gw_step:
             GW:
               CORR_MOS_OCC: '10'
               CORR_MOS_VIRT: '10'
-              EV_GW_ITER: '5'
+              EV_GW_ITER: '8'
               NPARAM_PADE: '16'
               RI_SIGMA_X: ''
       PRINT:
@@ -267,7 +267,7 @@ gapw_std_gw_step:
             GW:
               CORR_MOS_OCC: '10'
               CORR_MOS_VIRT: '10'
-              EV_GW_ITER: '5'
+              EV_GW_ITER: '8'
               RI_SIGMA_X: ''
       PRINT:
         MO_CUBES:
@@ -406,7 +406,7 @@ gapw_hq_gw_step:
             GW:
               CORR_MOS_OCC: '10'
               CORR_MOS_VIRT: '10'
-              EV_GW_ITER: '5'
+              EV_GW_ITER: '8'
               RI_SIGMA_X: ''
       PRINT:
         MO_CUBES:


### PR DESCRIPTION
Switched to the old `aug-DZVP` basis for H and C, which is also compatible with the basis sets of the other supported elements. Results in a 0.05-0.15 eV increase in GW+IC gaps that improves match with experiment.

Additionally, a spin guess bug was fixed.