### PR TITLE
magic fix

### DIFF
--- a/aiida_nanotech_empa/parsers/cubegen_pymol_parser.py
+++ b/aiida_nanotech_empa/parsers/cubegen_pymol_parser.py
@@ -62,9 +62,9 @@ class CubegenPymolParser(CubegenBaseParser):
                                         (0.0, 0.4, 1.0),  # blue
                                     ],
                                     orientations=('z'),
-                                    output_folder=image_folder.name,
+                                    output_folder=image_folder,
                                     output_name=os.path.splitext(filename)[0])
 
-            image_folder_node = FolderData(tree=image_folder.name)
+            image_folder_node = FolderData(tree=image_folder)
 
             self.out("cube_image_folder", image_folder_node)


### PR DESCRIPTION
No idea how it was working before.

Seemingly

`with tempfile.TemporaryDirectory() as image_folder:`

always has made `image_folder` a string, and `image_folder.name` gives an error.

