### PR TITLE
Removed from the cp2k GW workchains the "geometry_opt_mult" input. Fixes #103

### DIFF
--- a/aiida_nanotech_empa/workflows/cp2k/adsorbed_gw_ic_workchain.py
+++ b/aiida_nanotech_empa/workflows/cp2k/adsorbed_gw_ic_workchain.py
@@ -194,11 +194,6 @@ class Cp2kAdsorbedGwIcWorkChain(WorkChain):
                    default=lambda: Str("ads_geo"),
                    required=False,
                    help="Possibilities: ads_geo, gas_opt")
-        spec.input("geometry_opt_mult",
-                   valid_type=Int,
-                   default=lambda: Int(0),
-                   required=False,
-                   help="Multiplicity in case of 'gas opt' is selected.")
 
         spec.outline(cls.setup,
                      if_(cls.gas_opt_selected)(cls.gas_opt, cls.check_gas_opt),
@@ -256,7 +251,7 @@ class Cp2kAdsorbedGwIcWorkChain(WorkChain):
         builder = Cp2kMoleculeOptWorkChain.get_builder()
         builder.code = self.inputs.code
         builder.structure = self.ctx.mol_struct
-        builder.multiplicity = self.inputs.geometry_opt_mult
+        builder.multiplicity = self.inputs.multiplicity
         builder.magnetization_per_site = self.ctx.mol_mag_per_site
         builder.vdw = Bool(True)
         builder.protocol = Str('standard')

--- a/aiida_nanotech_empa/workflows/cp2k/molecule_opt_gw_workchain.py
+++ b/aiida_nanotech_empa/workflows/cp2k/molecule_opt_gw_workchain.py
@@ -94,11 +94,6 @@ class Cp2kMoleculeOptGwWorkChain(WorkChain):
                    default=lambda: Bool(True),
                    required=False,
                    help="Perform geo opt step.")
-        spec.input("geometry_opt_mult",
-                   valid_type=Int,
-                   default=lambda: Int(0),
-                   required=False,
-                   help="Multiplicity in case of 'gas opt' is selected.")
 
         spec.outline(cls.setup,
                      if_(cls.gas_opt_selected)(cls.gas_opt, cls.check_gas_opt),
@@ -136,7 +131,7 @@ class Cp2kMoleculeOptGwWorkChain(WorkChain):
         builder = Cp2kMoleculeOptWorkChain.get_builder()
         builder.code = self.inputs.code
         builder.structure = self.ctx.mol_struct
-        builder.multiplicity = self.inputs.geometry_opt_mult
+        builder.multiplicity = self.inputs.multiplicity
         builder.magnetization_per_site = self.ctx.mol_mag_per_site
         builder.vdw = Bool(True)
         builder.protocol = Str('standard')


### PR DESCRIPTION
This input was meant to allow running the geo_opt step in a GW workchain with a multiplicity different from the one used for the GW step. It was a source of confusion and errors.

Fixes #103