### PR TITLE
Use charge input in `slab/bulk/molecule` optimizations.

### DIFF
--- a/aiida_nanotech_empa/workflows/cp2k/bulk_opt_workchain.py
+++ b/aiida_nanotech_empa/workflows/cp2k/bulk_opt_workchain.py
@@ -119,6 +119,8 @@ class Cp2kBulkOptWorkChain(WorkChain):
                                   ".", "data", "POTENTIAL")),
         }
 
+        #charge
+        input_dict['FORCE_EVAL']['DFT']['CHARGE'] = self.inputs.charge.value
         # vdw
         if not self.inputs.vdw.value:
             input_dict['FORCE_EVAL']['DFT']['XC'].pop('VDW_POTENTIAL')

--- a/aiida_nanotech_empa/workflows/cp2k/molecule_opt_workchain.py
+++ b/aiida_nanotech_empa/workflows/cp2k/molecule_opt_workchain.py
@@ -109,6 +109,9 @@ class Cp2kMoleculeOptWorkChain(WorkChain):
                                   ".", "data", "POTENTIAL")),
         }
 
+        #charge
+        input_dict['FORCE_EVAL']['DFT']['CHARGE'] = self.inputs.charge.value
+
         # vdw
         if not self.inputs.vdw.value:
             input_dict['FORCE_EVAL']['DFT']['XC'].pop('VDW_POTENTIAL')

--- a/aiida_nanotech_empa/workflows/cp2k/slab_opt_workchain.py
+++ b/aiida_nanotech_empa/workflows/cp2k/slab_opt_workchain.py
@@ -103,6 +103,9 @@ class Cp2kSlabOptWorkChain(WorkChain):
                                   ".", "data", "POTENTIAL")),
         }
 
+
+        #charge
+        input_dict['FORCE_EVAL']['DFT']['CHARGE'] = self.inputs.charge.value
         # vdw
         if not self.inputs.vdw.value:
             input_dict['FORCE_EVAL']['DFT']['XC'].pop('VDW_POTENTIAL')

--- a/aiida_nanotech_empa/workflows/cp2k/slab_opt_workchain.py
+++ b/aiida_nanotech_empa/workflows/cp2k/slab_opt_workchain.py
@@ -103,7 +103,6 @@ class Cp2kSlabOptWorkChain(WorkChain):
                                   ".", "data", "POTENTIAL")),
         }
 
-
         #charge
         input_dict['FORCE_EVAL']['DFT']['CHARGE'] = self.inputs.charge.value
         # vdw


### PR DESCRIPTION
the workchains for slab/bulk/molecule optimization where not using the specified input for charge
fixes #86 