### PR TITLE
bug in cv dist: with POINTS also ATOMS is needed

### DIFF
--- a/aiida_nanotech_empa/workflows/cp2k/cp2k_utils.py
+++ b/aiida_nanotech_empa/workflows/cp2k/cp2k_utils.py
@@ -600,7 +600,7 @@ def get_points(details):
 
 
 def get_points_coords(points, atoms):
-    """Returns an ase Atoms object with H atoms positiones at the cartesian coordinates defined by the CP2K CV points."""
+    """Returns an ase Atoms object with H atoms positioned at the cartesian coordinates defined by the CP2K CV points."""
     coords = []
     for point in points:
         if point["TYPE"] == "FIX_POINT":
@@ -674,6 +674,7 @@ def cv_dist(details):
     # case of points
     else:
         return_dict = {"DISTANCE": points}
+        return_dict["DISTANCE"].update({"ATOMS": "1 2"})
 
     if axis:
         return_dict["DISTANCE"].update({"AXIS": details[axis[0] + 1].upper()})


### PR DESCRIPTION
In the case of points, the CV now contains the additional card: ATOMS 1 2 specifying the distance is between points 1 and 2