### PR TITLE
updating aiida qe plugging version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 requires-python = ">=3.8"
 dependencies = [
     "aiida-core~=2.2",
-    "aiida-quantumespresso<4.3",
+    "aiida-quantumespresso<4.5",
     "aiida-pseudo~=1.0",
     "aiida-cp2k~=2.0",
     "ase~=3.21",


### PR DESCRIPTION
To take into account the new `aiida-quantumespresso` plugin (4.4.0) 