### PR TITLE
Update aiida-qe plugin to `~=4.4`

### DIFF
--- a/aiida_nanotech_empa/parsers/pp_parser.py
+++ b/aiida_nanotech_empa/parsers/pp_parser.py
@@ -28,8 +28,6 @@ class PpParser(BasePpParser):
         voxel_array = cube.cell / np.atleast_2d(cube.data.shape).T
         numbers = cube.ase_atoms.numbers
 
-        # data_units = self.units_dict[self.output_parameters["plot_num"]]
-
         arraydata = orm.ArrayData()
         arraydata.set_array("voxel", voxel_array)
         arraydata.set_array("data", cube.data)

--- a/aiida_nanotech_empa/parsers/pp_parser.py
+++ b/aiida_nanotech_empa/parsers/pp_parser.py
@@ -15,7 +15,8 @@ class PpParser(BasePpParser):
     :param data_file_str: the data file read in as a single string
     """
 
-    def parse_gaussian(self, data_file_str):
+    @staticmethod
+    def parse_gaussian(data_file_str, data_units):
         with io.StringIO(data_file_str) as data_file_handle:
             cube = Cube.from_file_handle(data_file_handle)
 
@@ -27,7 +28,7 @@ class PpParser(BasePpParser):
         voxel_array = cube.cell / np.atleast_2d(cube.data.shape).T
         numbers = cube.ase_atoms.numbers
 
-        data_units = self.units_dict[self.output_parameters["plot_num"]]
+        # data_units = self.units_dict[self.output_parameters["plot_num"]]
 
         arraydata = orm.ArrayData()
         arraydata.set_array("voxel", voxel_array)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 requires-python = ">=3.8"
 dependencies = [
     "aiida-core~=2.2",
-    "aiida-quantumespresso<4.3",
+    "aiida-quantumespresso~=4.4",
     "aiida-pseudo~=1.0",
     "aiida-cp2k~=2.0",
     "ase~=3.21",


### PR DESCRIPTION
The PR https://github.com/aiidateam/aiida-quantumespresso/pull/756 introduced a backwards-incompatible change to the `parse_gaussian` method of the `PpParser` class. Here, we are restoring the compatibility with the later release of the aiida-qe plugin.
