### PR TITLE
set default symmetry to NONE in the geo_opt protocol

### DIFF
--- a/aiida_nanotech_empa/workflows/cp2k/protocols/geo_opt_protocol.yml
+++ b/aiida_nanotech_empa/workflows/cp2k/protocols/geo_opt_protocol.yml
@@ -26,7 +26,7 @@ phonons:
         SUBSYS:
             CELL:
                 PERIODIC: XYZ
-                SYMMETRY: ORTHORHOMBIC
+                SYMMETRY: NONE
         DFT:
             UKS: .FALSE.
             MULTIPLICITY: 0
@@ -126,7 +126,7 @@ standard:
         SUBSYS:
             CELL:
                 PERIODIC: XYZ
-                SYMMETRY: ORTHORHOMBIC
+                SYMMETRY: NONE
         DFT:
             UKS: .FALSE.
             MULTIPLICITY: 0
@@ -226,7 +226,7 @@ low_accuracy:
         SUBSYS:
             CELL:
                 PERIODIC: XYZ
-                SYMMETRY: ORTHORHOMBIC
+                SYMMETRY: NONE
         DFT:
             UKS: .FALSE.
             MULTIPLICITY: 0
@@ -326,7 +326,7 @@ debug:
         SUBSYS:
             CELL:
                 PERIODIC: XYZ
-                SYMMETRY: ORTHORHOMBIC
+                SYMMETRY: NONE
         DFT:
             UKS: .FALSE.
             MULTIPLICITY: 0


### PR DESCRIPTION
Otherwise, e.g. in slab opt, if the cell is not orthorhombic the results are wrong.
TBD update the info in the structure details of the geometry optimization app