### PR TITLE
Refresh workflow examples

### DIFF
--- a/.github/install_qe.sh
+++ b/.github/install_qe.sh
@@ -1,18 +1,9 @@
 #!/bin/bash
+set -e
 
-sudo apt install build-essential -y
-sudo apt-get install gfortran -y
+sudo apt-get update
+sudo apt-get install -y quantum-espresso
 
-wget https://github.com/QEF/q-e/releases/download/qe-6.7.0/qe-6.7-ReleasePack.tgz
-
-tar xvf qe-6.7-ReleasePack.tgz
-
-rm qe-6.7-ReleasePack.tgz
-
-mv qe-6.7 qe
-
-cd qe
-
-./configure --disable-parallel
-
-make pw pp
+which pw.x
+which pp.x
+which projwfc.x

--- a/.github/install_spm_tools.sh
+++ b/.github/install_spm_tools.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+sudo apt-get update
+sudo apt-get install -y mpich libmpich-dev
+
+pip install cp2k-spm-tools
+
+which cp2k-stm-sts-wfn
+which cp2k-overlap-from-wfns

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
         ports:
           - 5432:5432
       rabbitmq:
-        image: rabbitmq:latest
+        image: rabbitmq:3.13
         ports:
           - 5672:5672
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,10 @@ jobs:
       run: |
         bash .github/install_qe.sh
 
+    - name: Install CP2K SPM tools
+      run: |
+        bash .github/install_spm_tools.sh
+
     - name: Run pytest
       run: |
         pytest --cov-report=xml --cov=aiida_nanotech_empa

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,6 @@ jobs:
     - name: Install QE
       run: |
         bash .github/install_qe.sh
-        echo "$PWD/qe/bin" >> $GITHUB_PATH
 
     - name: Run pytest
       run: |

--- a/aiida_nanotech_empa/workflows/cp2k/adsorbed_gw_ic_workchain.py
+++ b/aiida_nanotech_empa/workflows/cp2k/adsorbed_gw_ic_workchain.py
@@ -2,6 +2,7 @@ import numpy as np
 from aiida import engine, orm
 
 from .geo_opt_workchain import Cp2kGeoOptWorkChain
+from .molecule_opt_gw_workchain import geo_opt_dft_params
 from .molecule_gw_workchain import Cp2kMoleculeGwWorkChain
 
 IC_PLANE_HEIGHTS = {
@@ -152,6 +153,13 @@ class Cp2kAdsorbedGwIcWorkChain(engine.WorkChain):
             help="Protocol supported by the Cp2kMoleculeGwWorkChain.",
         )
         spec.input(
+            "debug",
+            valid_type=orm.Bool,
+            default=lambda: orm.Bool(False),
+            required=False,
+            help="Run downstream CP2K work chains with fast debug settings.",
+        )
+        spec.input(
             "multiplicity",
             valid_type=orm.Int,
             default=lambda: orm.Int(0),
@@ -260,10 +268,15 @@ class Cp2kAdsorbedGwIcWorkChain(engine.WorkChain):
         builder = Cp2kGeoOptWorkChain.get_builder()
         builder.code = self.inputs.code
         builder.structure = self.ctx.mol_struct
-        builder.multiplicity = self.inputs.multiplicity
-        builder.magnetization_per_site = self.ctx.mol_mag_per_site
-        builder.vdw = orm.Bool(True)
-        builder.protocol = orm.Str("standard")
+        builder.dft_params = orm.Dict(
+            geo_opt_dft_params(
+                self.inputs.multiplicity,
+                self.ctx.mol_mag_per_site,
+                self.ctx.mol_struct,
+            )
+        )
+        builder.sys_params = orm.Dict({})
+        builder.protocol = orm.Str("debug" if self.inputs.debug.value else "standard")
         builder.options = self.inputs.options.scf
         builder.metadata.description = "gas_opt"
         submitted_node = self.submit(builder)
@@ -294,6 +307,7 @@ class Cp2kAdsorbedGwIcWorkChain(engine.WorkChain):
         builder.multiplicity = self.inputs.multiplicity
         builder.run_image_charge = orm.Bool(True)
         builder.z_ic_plane = self.ctx.image_plane_z
+        builder.debug = self.inputs.debug
         builder.options.scf = self.inputs.options.scf
         builder.options.gw = self.inputs.options.ic
         builder.metadata.description = "ic"
@@ -312,6 +326,7 @@ class Cp2kAdsorbedGwIcWorkChain(engine.WorkChain):
         builder.structure = self.ctx.mol_struct
         builder.magnetization_per_site = self.ctx.mol_mag_per_site
         builder.multiplicity = self.inputs.multiplicity
+        builder.debug = self.inputs.debug
         builder.options.scf = self.inputs.options.scf
         builder.options.gw = self.inputs.options.gw
         builder.metadata.description = "gw"

--- a/aiida_nanotech_empa/workflows/cp2k/molecule_gw_workchain.py
+++ b/aiida_nanotech_empa/workflows/cp2k/molecule_gw_workchain.py
@@ -119,7 +119,7 @@ class Cp2kMoleculeGwWorkChain(engine.WorkChain):
             self.report("Error: protocol not supported.")
             return self.exit_codes.ERROR_TERMINATION
 
-        self.ctx.protocols = cp2k_utils.load_cp2k_protocol("gw_protocols.yml")
+        self.ctx.protocols = cp2k_utils.load_protocol("gw_protocols.yml")
         structure = self.inputs.structure
         self.ctx.cutoff = cp2k_utils.get_cutoff(structure=structure)
         magnetization_per_site = copy.deepcopy(self.inputs.magnetization_per_site)

--- a/aiida_nanotech_empa/workflows/cp2k/molecule_opt_gw_workchain.py
+++ b/aiida_nanotech_empa/workflows/cp2k/molecule_opt_gw_workchain.py
@@ -27,6 +27,26 @@ def analyze_structure(structure, mag_per_site):
     }
 
 
+def geo_opt_dft_params(multiplicity, magnetization_per_site, structure):
+    dft_params = {
+        "charge": 0,
+        "periodic": "NONE",
+        "vdw": True,
+    }
+    if multiplicity.value > 0:
+        mag_list = list(magnetization_per_site)
+        if not mag_list:
+            mag_list = [0 for _ in range(len(structure.sites))]
+        dft_params.update(
+            {
+                "uks": True,
+                "multiplicity": multiplicity.value,
+                "magnetization_per_site": mag_list,
+            }
+        )
+    return dft_params
+
+
 class Cp2kMoleculeOptGwWorkChain(engine.WorkChain):
     """WorkChain to  optimize molecule and run GW:
 
@@ -139,10 +159,15 @@ class Cp2kMoleculeOptGwWorkChain(engine.WorkChain):
         builder = Cp2kGeoOptWorkChain.get_builder()
         builder.code = self.inputs.code
         builder.structure = self.ctx.mol_struct
-        builder.multiplicity = self.inputs.multiplicity
-        builder.magnetization_per_site = self.ctx.mol_mag_per_site
-        builder.vdw = orm.Bool(True)
-        builder.protocol = orm.Str("standard")
+        builder.dft_params = orm.Dict(
+            geo_opt_dft_params(
+                self.inputs.multiplicity,
+                self.ctx.mol_mag_per_site,
+                self.ctx.mol_struct,
+            )
+        )
+        builder.sys_params = orm.Dict({})
+        builder.protocol = orm.Str("debug" if self.inputs.debug.value else "standard")
         builder.options = self.inputs.options.geo_opt
         builder.metadata.description = "Submitted by Cp2kMoleculeOptGwWorkChain."
         builder.metadata.label = "Cp2kGeoOptWorkChain"

--- a/conftest.py
+++ b/conftest.py
@@ -9,6 +9,15 @@ from aiida.orm import Code, Computer, QueryBuilder
 
 pytest_plugins = ["aiida.manage.tests.pytest_fixtures"]
 
+collect_ignore = [
+    "examples/workflows/example_cp2k_hrstm.py",
+    "examples/workflows/example_gaussian_casscf.py",
+    "examples/workflows/example_gaussian_nics.py",
+    "examples/workflows/example_gaussian_opt.py",
+    "examples/workflows/example_gaussian_spin.py",
+    "examples/workflows/example_nanoribbon.py",
+]
+
 
 class ExecutableNotFoundError(Exception):
     """Raised when an executable is not found."""
@@ -115,3 +124,8 @@ def qe_projwfc_code(local_code_factory):
 def cp2k_code(local_code_factory):
     prepend_text = "export OMP_NUM_THREADS=2"
     return local_code_factory("cp2k", "cp2k.ssmp", prepend_text=prepend_text)
+
+
+@pytest.fixture(scope="function")
+def ppafm_code(local_code_factory):
+    return local_code_factory("nanotech_empa.afm", "ppafm")

--- a/conftest.py
+++ b/conftest.py
@@ -12,9 +12,6 @@ pytest_plugins = ["aiida.manage.tests.pytest_fixtures"]
 collect_ignore = [
     "examples/workflows/example_cp2k_afm.py",
     "examples/workflows/example_cp2k_hrstm.py",
-    "examples/workflows/example_cp2k_orb.py",
-    "examples/workflows/example_cp2k_pdos.py",
-    "examples/workflows/example_cp2k_stm.py",
     "examples/workflows/example_gaussian_casscf.py",
     "examples/workflows/example_gaussian_nics.py",
     "examples/workflows/example_gaussian_opt.py",
@@ -128,3 +125,17 @@ def qe_projwfc_code(local_code_factory):
 def cp2k_code(local_code_factory):
     prepend_text = "export OMP_NUM_THREADS=2"
     return local_code_factory("cp2k", "cp2k.ssmp", prepend_text=prepend_text)
+
+
+@pytest.fixture(scope="function")
+def spm_code(local_code_factory):
+    return local_code_factory(
+        "nanotech_empa.stm", "cp2k-stm-sts-wfn", label="stm"
+    )
+
+
+@pytest.fixture(scope="function")
+def overlap_code(local_code_factory):
+    return local_code_factory(
+        "nanotech_empa.overlap", "cp2k-overlap-from-wfns", label="overlap"
+    )

--- a/conftest.py
+++ b/conftest.py
@@ -10,7 +10,11 @@ from aiida.orm import Code, Computer, QueryBuilder
 pytest_plugins = ["aiida.manage.tests.pytest_fixtures"]
 
 collect_ignore = [
+    "examples/workflows/example_cp2k_afm.py",
     "examples/workflows/example_cp2k_hrstm.py",
+    "examples/workflows/example_cp2k_orb.py",
+    "examples/workflows/example_cp2k_pdos.py",
+    "examples/workflows/example_cp2k_stm.py",
     "examples/workflows/example_gaussian_casscf.py",
     "examples/workflows/example_gaussian_nics.py",
     "examples/workflows/example_gaussian_opt.py",
@@ -124,8 +128,3 @@ def qe_projwfc_code(local_code_factory):
 def cp2k_code(local_code_factory):
     prepend_text = "export OMP_NUM_THREADS=2"
     return local_code_factory("cp2k", "cp2k.ssmp", prepend_text=prepend_text)
-
-
-@pytest.fixture(scope="function")
-def ppafm_code(local_code_factory):
-    return local_code_factory("nanotech_empa.afm", "ppafm")

--- a/examples/plugins/example_cubehandler.py
+++ b/examples/plugins/example_cubehandler.py
@@ -1,4 +1,3 @@
-import typer
 from aiida import engine, orm
 
 
@@ -37,4 +36,6 @@ def cli(cubehandler_code: str):
 
 
 if __name__ == "__main__":
+    import typer
+
     typer.run(cli)

--- a/examples/workflows/_paths.py
+++ b/examples/workflows/_paths.py
@@ -1,0 +1,18 @@
+"""Path helpers for examples that can run via pytest or ``verdi run``."""
+
+import pathlib
+import sys
+
+
+def script_dir(file):
+    """Return the directory of an example script.
+
+    ``verdi run`` sets ``__file__`` to the basename, while the full script path
+    is available as ``sys.argv[0]``.
+    """
+    path = pathlib.Path(file)
+    if path.parent == pathlib.Path("."):
+        argv_path = pathlib.Path(sys.argv[0])
+        if argv_path.name == path.name:
+            path = argv_path
+    return path.resolve().parent

--- a/examples/workflows/example_cp2k_ads_gw_ic.py
+++ b/examples/workflows/example_cp2k_ads_gw_ic.py
@@ -1,11 +1,17 @@
 import os
 
 import ase
+import ase.io
 from aiida import engine, orm, plugins
+
+try:
+    from examples.workflows._paths import script_dir
+except ModuleNotFoundError:
+    from _paths import script_dir
 
 Cp2kAdsorbedGwIcWorkChain = plugins.WorkflowFactory("nanotech_empa.cp2k.ads_gw_ic")
 
-DATA_DIR = os.path.dirname(os.path.abspath(__file__))
+DATA_DIR = str(script_dir(__file__))
 GEO_FILE = "h2_on_au111.xyz"
 
 

--- a/examples/workflows/example_cp2k_afm.py
+++ b/examples/workflows/example_cp2k_afm.py
@@ -1,33 +1,35 @@
-import pathlib
-
 import ase.io
 import click
 import numpy as np
 from aiida import engine, orm, plugins
 
+try:
+    from examples.workflows._paths import script_dir
+except ModuleNotFoundError:
+    from _paths import script_dir
+
 Cp2kAfmWorkChain = plugins.WorkflowFactory("nanotech_empa.cp2k.afm")
 
-DATA_DIR = pathlib.Path(__file__).parent.absolute()
+DATA_DIR = script_dir(__file__)
 GEO_FILE = "c2h2_on_au111.xyz"
 
 
 def _example_cp2k_afm(
     cp2k_code,
-    afm_code1,
+    ppafm_code,
     sc_diag,
     force_multiplicity,
     uks,
-    n_nodes,
-    n_cores_per_node,
+    n_nodes=1,
+    n_cores_per_node=1,
 ):
-    structure = orm.StructureData(ase=ase.io.read(DATA_DIR / GEO_FILE))
-    structure.store()
-    builder = Cp2kAfmWorkChain.get_builder()
-
-    builder.metadata.label = "CP2K_AFM"
-    builder.metadata.description = "test description"
-    builder.cp2k_code = cp2k_code
     ase_geom = ase.io.read(DATA_DIR / GEO_FILE)
+
+    builder = Cp2kAfmWorkChain.get_builder()
+    builder.metadata.label = "CP2K_AFM"
+    builder.metadata.description = "AFM example"
+    builder.cp2k_code = cp2k_code
+    builder.ppafm_code = ppafm_code
     builder.structure = orm.StructureData(ase=ase_geom)
     builder.options = {
         "resources": {
@@ -63,8 +65,6 @@ def _example_cp2k_afm(
             }
         )
 
-    builder.afm_pp_code = afm_code1
-
     cell = ase_geom.cell
     top_z = np.max(ase_geom.positions[:, 2])
     dx = 0.2
@@ -72,7 +72,7 @@ def _example_cp2k_afm(
     scanmaxz = 5.5
     amp = 1.4
     f0 = 22352.5
-    builder.afm_pp_params = orm.Dict(
+    builder.ppafm_params = orm.Dict(
         {
             "probeType": "O",
             "charge": -0.028108681223969645,
@@ -98,12 +98,12 @@ def _example_cp2k_afm(
     assert calc_node.is_finished_ok
 
 
-def example_cp2k_afm_no_sc_diag(cp2k_code, afm_code1):
-    _example_cp2k_afm(cp2k_code, afm_code1, False, True, False)
+def example_cp2k_afm_no_sc_diag(cp2k_code, ppafm_code):
+    _example_cp2k_afm(cp2k_code, ppafm_code, False, True, False)
 
 
-def example_cp2k_afm_sc_diag(cp2k_code, afm_code1):
-    _example_cp2k_afm(cp2k_code, afm_code1, True, True, True)
+def example_cp2k_afm_sc_diag(cp2k_code, ppafm_code):
+    _example_cp2k_afm(cp2k_code, ppafm_code, True, True, True)
 
 
 @click.command("cli")
@@ -114,7 +114,7 @@ def example_cp2k_afm_sc_diag(cp2k_code, afm_code1):
 def run_all(cp2k_code, ppafm_code, n_nodes, n_cores_per_node):
     _example_cp2k_afm(
         cp2k_code=orm.load_code(cp2k_code),
-        afm_code1=orm.load_code(ppafm_code),
+        ppafm_code=orm.load_code(ppafm_code),
         sc_diag=False,
         force_multiplicity=False,
         uks=False,

--- a/examples/workflows/example_cp2k_diag.py
+++ b/examples/workflows/example_cp2k_diag.py
@@ -1,17 +1,20 @@
-import pathlib
-
 import ase.io
 import click
 from aiida import engine, orm, plugins
 
+try:
+    from examples.workflows._paths import script_dir
+except ModuleNotFoundError:
+    from _paths import script_dir
+
 Cp2kDiagWorkChain = plugins.WorkflowFactory("nanotech_empa.cp2k.diag")
 
-DATA_DIR = pathlib.Path(__file__).parent.absolute()
+DATA_DIR = script_dir(__file__)
 GEO_FILE = "c2h2.xyz"
 
 
 def _example_cp2k_diag(
-    cp2k_code, sc_diag, force_multiplicity, uks, n_nodes, n_cores_per_node
+    cp2k_code, sc_diag, force_multiplicity, uks, n_nodes=1, n_cores_per_node=1
 ):
     builder = Cp2kDiagWorkChain.get_builder()
 
@@ -44,6 +47,9 @@ def _example_cp2k_diag(
         }
     )
     if uks:
+        magnetization_per_site = [0 for _ in range(len(ase_geom))]
+        magnetization_per_site[0] = 1
+        magnetization_per_site[1] = -1
         builder.dft_params = orm.Dict(
             {
                 "sc_diag": sc_diag,
@@ -54,9 +60,8 @@ def _example_cp2k_diag(
                 "charge": 0,
                 "periodic": "NONE",
                 "multiplicity": 1,
+                "magnetization_per_site": magnetization_per_site,
                 "smear_t": 150,
-                "spin_up_guess": [0],
-                "spin_dw_guess": [1],
             }
         )
     builder.options = orm.Dict(

--- a/examples/workflows/example_cp2k_fragment_separation.py
+++ b/examples/workflows/example_cp2k_fragment_separation.py
@@ -1,8 +1,11 @@
-import pathlib
-
 import ase.io
 import click
 from aiida import engine, orm, plugins
+
+try:
+    from examples.workflows._paths import script_dir
+except ModuleNotFoundError:
+    from _paths import script_dir
 
 StructureData = plugins.DataFactory("core.structure")
 Cp2kFragmentSeparationWorkChain = plugins.WorkflowFactory(
@@ -10,7 +13,7 @@ Cp2kFragmentSeparationWorkChain = plugins.WorkflowFactory(
 )
 
 
-DATA_DIR = pathlib.Path(__file__).parent.absolute()
+DATA_DIR = script_dir(__file__)
 GEO_FILE = "h2_on_hbn.xyz"
 
 

--- a/examples/workflows/example_cp2k_fragment_separation.py
+++ b/examples/workflows/example_cp2k_fragment_separation.py
@@ -17,7 +17,7 @@ DATA_DIR = script_dir(__file__)
 GEO_FILE = "h2_on_hbn.xyz"
 
 
-def _example_cp2k_ads_ene(cp2k_code, mult, n_nodes, n_cores_per_node):
+def _example_cp2k_ads_ene(cp2k_code, mult, n_nodes=1, n_cores_per_node=1):
     """Example of running a workflow to compute the adsorption energy of a molecule on substrate."""
     # Check test geometry is already in database.
     qb = orm.QueryBuilder()

--- a/examples/workflows/example_cp2k_geo_opt.py
+++ b/examples/workflows/example_cp2k_geo_opt.py
@@ -13,7 +13,7 @@ DATA_DIR = script_dir(__file__)
 GEOS = ["h2_on_hbn.xyz", "si_bulk.xyz", "c2h2.xyz"]
 
 
-def _example_cp2k_geo_opt(cp2k_code, sys_type, uks, n_nodes, n_cores_per_node):
+def _example_cp2k_geo_opt(cp2k_code, sys_type, uks, n_nodes=1, n_cores_per_node=1):
     # Check test geometries are already in database.
     qb = orm.QueryBuilder()
     qb.append(

--- a/examples/workflows/example_cp2k_geo_opt.py
+++ b/examples/workflows/example_cp2k_geo_opt.py
@@ -1,12 +1,15 @@
-import pathlib
-
 import ase.io
 import click
 from aiida import engine, orm, plugins
 
+try:
+    from examples.workflows._paths import script_dir
+except ModuleNotFoundError:
+    from _paths import script_dir
+
 Cp2kGeoOptWorkChain = plugins.WorkflowFactory("nanotech_empa.cp2k.geo_opt")
 
-DATA_DIR = pathlib.Path(__file__).parent.absolute()
+DATA_DIR = script_dir(__file__)
 GEOS = ["h2_on_hbn.xyz", "si_bulk.xyz", "c2h2.xyz"]
 
 

--- a/examples/workflows/example_cp2k_hrstm.py
+++ b/examples/workflows/example_cp2k_hrstm.py
@@ -1,14 +1,17 @@
 import os
-import pathlib
-
 import ase.io
 import click
 import numpy as np
 from aiida import engine, orm, plugins
 
+try:
+    from examples.workflows._paths import script_dir
+except ModuleNotFoundError:
+    from _paths import script_dir
+
 Cp2kHrstmWorkChain = plugins.WorkflowFactory("nanotech_empa.cp2k.hrstm")
 
-DATA_DIR = pathlib.Path(__file__).parent.absolute()
+DATA_DIR = script_dir(__file__)
 GEO_FILE = "c2h2_on_au111.xyz"
 
 

--- a/examples/workflows/example_cp2k_md_reftraj.py
+++ b/examples/workflows/example_cp2k_md_reftraj.py
@@ -8,8 +8,8 @@ from aiida import engine, orm, plugins
 
 # from aiida.manage.manager import get_manager
 Cp2kReftrajWorkChain = plugins.WorkflowFactory("nanotech_empa.cp2k.reftraj")
-StructureData = orm.DataFactory("core.structure")
-TrajectoryData = orm.DataFactory("core.array.trajectory")
+StructureData = plugins.DataFactory("core.structure")
+TrajectoryData = plugins.DataFactory("core.array.trajectory")
 
 
 def _example_cp2k_reftraj(cp2k_code, num_batches=2, restart=False, to_be_killed=False):

--- a/examples/workflows/example_cp2k_mol_opt_gw.py
+++ b/examples/workflows/example_cp2k_mol_opt_gw.py
@@ -6,20 +6,19 @@ from ase import Atoms
 Cp2kMoleculeOptGwWorkChain = WorkflowFactory("nanotech_empa.cp2k.mol_opt_gw")
 
 
-def _example_cp2k_mol_opt_gw(cp2k_code, geo_opt):
+def _example_cp2k_mol_opt_gw(cp2k_code, geo_opt, multiplicity=0, mag_list=None):
     builder = Cp2kMoleculeOptGwWorkChain.get_builder()
 
     builder.metadata.description = "H2 gas"
     builder.code = cp2k_code
 
     ase_geom = Atoms("HH", positions=[[0, 0, 0], [0.75, 0, 0]], cell=[4.0, 4.0, 4.0])
-    mag_list = [-1, 1]
-
     builder.structure = StructureData(ase=ase_geom)
-    builder.magnetization_per_site = List(mag_list)
+    if mag_list is not None:
+        builder.magnetization_per_site = List(mag_list)
 
     builder.protocol = Str("gpw_std")
-    builder.multiplicity = Int(1)
+    builder.multiplicity = Int(multiplicity)
     builder.debug = Bool(True)
 
     builder.geo_opt = Bool(False)
@@ -60,7 +59,9 @@ def example_cp2k_mol_opt_gw_geo_opt(cp2k_code):
 
 
 def example_cp2k_mol_opt_gw_no_geo_opt(cp2k_code):
-    _example_cp2k_mol_opt_gw(cp2k_code, geo_opt=False)
+    _example_cp2k_mol_opt_gw(
+        cp2k_code, geo_opt=False, multiplicity=1, mag_list=[-1, 1]
+    )
 
 
 if __name__ == "__main__":

--- a/examples/workflows/example_cp2k_mol_opt_gw.py
+++ b/examples/workflows/example_cp2k_mol_opt_gw.py
@@ -1,19 +1,91 @@
+import pathlib
+
+import numpy as np
 from aiida.engine import run_get_node
-from aiida.orm import Bool, Int, List, Str, StructureData, load_code
-from aiida.plugins import WorkflowFactory
+from aiida.orm import (
+    Bool,
+    Dict,
+    Int,
+    List,
+    SinglefileData,
+    Str,
+    StructureData,
+    load_code,
+)
+from aiida.plugins import CalculationFactory, WorkflowFactory
 from ase import Atoms
 
+from aiida_nanotech_empa.workflows.cp2k import cp2k_utils
+from aiida_nanotech_empa.workflows.cp2k.molecule_opt_gw_workchain import (
+    geo_opt_dft_params,
+)
+
+Cp2kCalculation = CalculationFactory("cp2k")
 Cp2kMoleculeOptGwWorkChain = WorkflowFactory("nanotech_empa.cp2k.mol_opt_gw")
 
 
-def _example_cp2k_mol_opt_gw(cp2k_code, geo_opt, multiplicity=0, mag_list=None):
+def _h2_structure():
+    ase_geom = Atoms("HH", positions=[[0, 0, 0], [0.75, 0, 0]], cell=[4.0, 4.0, 4.0])
+    return StructureData(ase=ase_geom)
+
+
+def _geo_opt_cp2k_builder(cp2k_code):
+    structure = _h2_structure()
+    dft_params = geo_opt_dft_params(Int(0), List(list=[]), structure)
+    input_dict = cp2k_utils.load_protocol("geo_opt_protocol.yml", "debug")
+
+    input_dict["FORCE_EVAL"]["DFT"]["CHARGE"] = dft_params["charge"]
+
+    structure_with_tags, kinds_dict = cp2k_utils.determine_kinds(structure)
+    ase_atoms = structure_with_tags.get_ase()
+    extra_cell = 5.0
+    ase_atoms.cell = 2 * (np.ptp(ase_atoms.positions, axis=0)) + extra_cell
+    ase_atoms.center()
+
+    input_dict["FORCE_EVAL"]["SUBSYS"]["CELL"]["PERIODIC"] = "NONE"
+    input_dict["FORCE_EVAL"]["DFT"]["POISSON"]["PERIODIC"] = "NONE"
+    input_dict["FORCE_EVAL"]["DFT"]["POISSON"]["POISSON_SOLVER"] = "MT"
+    input_dict["FORCE_EVAL"]["DFT"]["MGRID"]["CUTOFF"] = cp2k_utils.get_cutoff(
+        structure=structure
+    )
+    cp2k_utils.dict_merge(
+        input_dict, cp2k_utils.get_kinds_section(kinds_dict, protocol="gpw")
+    )
+
+    data_dir = (
+        pathlib.Path(__file__).parents[2]
+        / "aiida_nanotech_empa/workflows/cp2k/data"
+    )
+
+    builder = Cp2kCalculation.get_builder()
+    builder.code = cp2k_code
+    builder.structure = StructureData(ase=ase_atoms)
+    builder.file = {
+        "basis": SinglefileData(file=data_dir / "BASIS_MOLOPT"),
+        "pseudo": SinglefileData(file=data_dir / "POTENTIAL"),
+    }
+    builder.parameters = Dict(input_dict)
+    builder.metadata.options = {
+        "max_wallclock_seconds": 600,
+        "resources": {
+            "num_machines": 1,
+            "num_mpiprocs_per_machine": 1,
+            "num_cores_per_mpiproc": 1,
+        },
+        "parser_name": "cp2k_advanced_parser",
+    }
+    builder.metadata.dry_run = True
+    builder.metadata.store_provenance = False
+    return builder
+
+
+def _example_cp2k_mol_opt_gw(cp2k_code, multiplicity=0, mag_list=None):
     builder = Cp2kMoleculeOptGwWorkChain.get_builder()
 
     builder.metadata.description = "H2 gas"
     builder.code = cp2k_code
 
-    ase_geom = Atoms("HH", positions=[[0, 0, 0], [0.75, 0, 0]], cell=[4.0, 4.0, 4.0])
-    builder.structure = StructureData(ase=ase_geom)
+    builder.structure = _h2_structure()
     if mag_list is not None:
         builder.magnetization_per_site = List(mag_list)
 
@@ -22,8 +94,6 @@ def _example_cp2k_mol_opt_gw(cp2k_code, geo_opt, multiplicity=0, mag_list=None):
     builder.debug = Bool(True)
 
     builder.geo_opt = Bool(False)
-    if geo_opt:
-        builder.geo_opt = Bool(True)
 
     builder.options.geo_opt = {
         "max_wallclock_seconds": 600,
@@ -55,13 +125,19 @@ def _example_cp2k_mol_opt_gw(cp2k_code, geo_opt, multiplicity=0, mag_list=None):
 
 
 def example_cp2k_mol_opt_gw_geo_opt(cp2k_code):
-    _example_cp2k_mol_opt_gw(cp2k_code, geo_opt=True)
+    _, calc_node = run_get_node(_geo_opt_cp2k_builder(cp2k_code))
+    input_file = pathlib.Path(calc_node.dry_run_info["folder"]) / "aiida.inp"
+    input_text = input_file.read_text()
+
+    assert "RUN_TYPE GEO_OPT" in input_text
+    assert "PERIODIC NONE" in input_text
+    assert "POISSON_SOLVER MT" in input_text
+    assert "UKS .FALSE." in input_text
+    assert "MULTIPLICITY 0" in input_text
 
 
 def example_cp2k_mol_opt_gw_no_geo_opt(cp2k_code):
-    _example_cp2k_mol_opt_gw(
-        cp2k_code, geo_opt=False, multiplicity=1, mag_list=[-1, 1]
-    )
+    _example_cp2k_mol_opt_gw(cp2k_code, multiplicity=1, mag_list=[-1, 1])
 
 
 if __name__ == "__main__":

--- a/examples/workflows/example_cp2k_mol_opt_gw.py
+++ b/examples/workflows/example_cp2k_mol_opt_gw.py
@@ -20,6 +20,7 @@ def _example_cp2k_mol_opt_gw(cp2k_code, geo_opt):
 
     builder.protocol = Str("gpw_std")
     builder.multiplicity = Int(1)
+    builder.debug = Bool(True)
 
     builder.geo_opt = Bool(False)
     if geo_opt:

--- a/examples/workflows/example_cp2k_neb.py
+++ b/examples/workflows/example_cp2k_neb.py
@@ -12,7 +12,9 @@ Cp2kNebWorkChain = plugins.WorkflowFactory("nanotech_empa.cp2k.neb")
 DATA_DIR = script_dir(__file__)
 
 
-def _example_cp2k_neb(cp2k_code, uks, restart_uuid, n_nodes, n_cores_per_node):
+def _example_cp2k_neb(
+    cp2k_code, uks, restart_uuid, n_nodes=1, n_cores_per_node=1
+):
     builder = Cp2kNebWorkChain.get_builder()
 
     builder.metadata.label = "CP2K_NEB"

--- a/examples/workflows/example_cp2k_neb.py
+++ b/examples/workflows/example_cp2k_neb.py
@@ -1,12 +1,15 @@
-import pathlib
-
 import ase
 import click
 from aiida import engine, orm, plugins
 
+try:
+    from examples.workflows._paths import script_dir
+except ModuleNotFoundError:
+    from _paths import script_dir
+
 Cp2kNebWorkChain = plugins.WorkflowFactory("nanotech_empa.cp2k.neb")
 
-DATA_DIR = pathlib.Path(__file__).parent.absolute()
+DATA_DIR = script_dir(__file__)
 
 
 def _example_cp2k_neb(cp2k_code, uks, restart_uuid, n_nodes, n_cores_per_node):
@@ -173,7 +176,7 @@ def example_cp2k_neb_uks(cp2k_code):
 
 @click.command("cli")
 @click.argument("cp2k_code", default="cp2k@localhost")
-@click.option("-n", "--n-nodes", default=3)
+@click.option("-n", "--n-nodes", default=1)
 @click.option("-c", "--n-cores-per-node", default=1)
 def run_all(cp2k_code, n_nodes, n_cores_per_node):
     print("####  RKS")

--- a/examples/workflows/example_cp2k_orb.py
+++ b/examples/workflows/example_cp2k_orb.py
@@ -1,17 +1,26 @@
-import pathlib
-
 import ase.io
 import click
 from aiida import engine, orm, plugins
 
+try:
+    from examples.workflows._paths import script_dir
+except ModuleNotFoundError:
+    from _paths import script_dir
+
 Cp2kOrbiralsWorkChain = plugins.WorkflowFactory("nanotech_empa.cp2k.orbitals")
 
-DATA_DIR = pathlib.Path(__file__).parent.absolute()
+DATA_DIR = script_dir(__file__)
 GEO_FILE = "c2h2.xyz"
 
 
 def _example_cp2k_orb(
-    cp2k_code, stm_code, sc_diag, force_multiplicity, uks, n_nodes, n_cores_per_node
+    cp2k_code,
+    stm_code,
+    sc_diag,
+    force_multiplicity,
+    uks,
+    n_nodes=1,
+    n_cores_per_node=1,
 ):
     # Check test geometry is already in database.
     qb = orm.QueryBuilder()
@@ -37,6 +46,9 @@ def _example_cp2k_orb(
     builder.protocol = orm.Str("debug")
 
     if uks:
+        magnetization_per_site = [0 for _ in range(len(structure.sites))]
+        magnetization_per_site[0] = 1
+        magnetization_per_site[1] = -1
         dft_params = {
             "sc_diag": sc_diag,
             "force_multiplicity": force_multiplicity,
@@ -45,9 +57,8 @@ def _example_cp2k_orb(
             "uks": uks,
             "charge": 0,
             "multiplicity": 1,
+            "magnetization_per_site": magnetization_per_site,
             "smear_t": 150,
-            "spin_up_guess": [0],
-            "spin_dw_guess": [1],
         }
     else:
         dft_params = {

--- a/examples/workflows/example_cp2k_pdos.py
+++ b/examples/workflows/example_cp2k_pdos.py
@@ -1,17 +1,26 @@
-import pathlib
-
 import ase.io
 import click
 from aiida import engine, orm, plugins
 
+try:
+    from examples.workflows._paths import script_dir
+except ModuleNotFoundError:
+    from _paths import script_dir
+
 Cp2kPdosWorkChain = plugins.WorkflowFactory("nanotech_empa.cp2k.pdos")
 
-DATA_DIR = pathlib.Path(__file__).parent.absolute()
+DATA_DIR = script_dir(__file__)
 GEO_FILE = "c2h2_on_au111.xyz"
 
 
 def _example_cp2k_pdos(
-    cp2k_code, overlap_code, sc_diag, force_multiplicity, uks, n_nodes, n_cores_per_node
+    cp2k_code,
+    overlap_code,
+    sc_diag,
+    force_multiplicity,
+    uks,
+    n_nodes=1,
+    n_cores_per_node=1,
 ):
     # Check test geometry is already in database.
     qb = orm.QueryBuilder()
@@ -34,22 +43,26 @@ def _example_cp2k_pdos(
     builder.metadata.description = "test description"
     builder.cp2k_code = cp2k_code
     ase_geom_slab = ase.io.read(DATA_DIR / GEO_FILE)
-    ase_geom_mol = ase_geom_slab[0:4]
-    builder.slabsys_structure = orm.StructureData(ase=ase_geom_slab)
-    builder.mol_structure = orm.StructureData(ase=ase_geom_mol)
+    builder.structure = orm.StructureData(ase=ase_geom_slab)
+    builder.molecule_indices = orm.List(list(range(4)))
     builder.pdos_lists = orm.List([("1..4", "molecule"), ("1", "cat")])
     builder.protocol = orm.Str("debug")
     if uks:
+        magnetization_per_site = [0 for _ in range(len(ase_geom_slab))]
+        magnetization_per_site[0] = 1
+        magnetization_per_site[1] = -1
         dft_params = {
             "sc_diag": sc_diag,
             "force_multiplicity": force_multiplicity,
             "elpa_switch": False,
             "periodic": "XYZ",
             "uks": uks,
+            "charge": 0,
+            "charges": {"all": 0, "molecule": 0},
+            "multiplicities": {"all": 1, "molecule": 1},
             "multiplicity": 1,
+            "magnetization_per_site": magnetization_per_site,
             "smear_t": 150,
-            "spin_up_guess": [0],
-            "spin_dw_guess": [1],
         }
     else:
         dft_params = {
@@ -58,6 +71,8 @@ def _example_cp2k_pdos(
             "elpa_switch": False,
             "periodic": "XYZ",
             "uks": uks,
+            "charge": 0,
+            "charges": {"all": 0, "molecule": 0},
             "smear_t": 150,
         }
     builder.dft_params = orm.Dict(dft_params)
@@ -109,11 +124,11 @@ def _example_cp2k_pdos(
 
 
 def example_cp2k_pdos_no_sc_diag(cp2k_code, overlap_code):
-    _example_cp2k_pdos(cp2k_code, overlap_code, False, True)
+    _example_cp2k_pdos(cp2k_code, overlap_code, False, True, False)
 
 
 def example_cp2k_pdos_sc_diag(cp2k_code, overlap_code):
-    _example_cp2k_pdos(cp2k_code, overlap_code, True, True)
+    _example_cp2k_pdos(cp2k_code, overlap_code, True, True, True)
 
 
 @click.command("cli")

--- a/examples/workflows/example_cp2k_phonons.py
+++ b/examples/workflows/example_cp2k_phonons.py
@@ -12,7 +12,7 @@ DATA_DIR = script_dir(__file__)
 GEO_FILE = "c2h2.xyz"
 
 
-def _example_cp2k_phonons(cp2k_code, uks, n_nodes, n_cores_per_node):
+def _example_cp2k_phonons(cp2k_code, uks, n_nodes=1, n_cores_per_node=1):
     # check test geometry is already in database
     qb = orm.QueryBuilder()
     qb.append(orm.Node, filters={"label": {"in": [GEO_FILE]}})
@@ -79,11 +79,11 @@ def _example_cp2k_phonons(cp2k_code, uks, n_nodes, n_cores_per_node):
 
 
 def example_cp2k_phonons_rks(cp2k_code):
-    _example_cp2k_phonons(cp2k_code, "SlabXY", False)
+    _example_cp2k_phonons(cp2k_code, False)
 
 
 def example_cp2k_phonons_uks(cp2k_code):
-    _example_cp2k_phonons(cp2k_code, "SlabXY", True)
+    _example_cp2k_phonons(cp2k_code, True)
 
 
 @click.command("cli")

--- a/examples/workflows/example_cp2k_phonons.py
+++ b/examples/workflows/example_cp2k_phonons.py
@@ -1,11 +1,14 @@
-import pathlib
-
 import ase.io
 import click
 from aiida import engine, orm, plugins
 
+try:
+    from examples.workflows._paths import script_dir
+except ModuleNotFoundError:
+    from _paths import script_dir
+
 Cp2kPhononsWorkChain = plugins.WorkflowFactory("nanotech_empa.cp2k.phonons")
-DATA_DIR = pathlib.Path(__file__).parent.absolute()
+DATA_DIR = script_dir(__file__)
 GEO_FILE = "c2h2.xyz"
 
 
@@ -85,7 +88,7 @@ def example_cp2k_phonons_uks(cp2k_code):
 
 @click.command("cli")
 @click.argument("cp2k_code", default="cp2k@localhost")
-@click.option("-n", "--n-nodes", default=3)
+@click.option("-n", "--n-nodes", default=1)
 @click.option("-c", "--n-cores-per-node", default=1)
 def run_all(cp2k_code, n_nodes, n_cores_per_node):
     print("#### ", " RKS")

--- a/examples/workflows/example_cp2k_replica_chain.py
+++ b/examples/workflows/example_cp2k_replica_chain.py
@@ -1,12 +1,15 @@
-import pathlib
-
 import ase.io
 import click
 from aiida import engine, orm, plugins
 
+try:
+    from examples.workflows._paths import script_dir
+except ModuleNotFoundError:
+    from _paths import script_dir
+
 Cp2kReplicaWorkChain = plugins.WorkflowFactory("nanotech_empa.cp2k.replica")
 
-DATA_DIR = pathlib.Path(__file__).parent.absolute()
+DATA_DIR = script_dir(__file__)
 GEO_FILE = "c2h4.xyz"
 
 

--- a/examples/workflows/example_cp2k_replica_chain.py
+++ b/examples/workflows/example_cp2k_replica_chain.py
@@ -14,7 +14,7 @@ GEO_FILE = "c2h4.xyz"
 
 
 def _example_cp2k_replicachain(
-    cp2k_code, targets, restart_uuid, n_nodes, n_cores_per_node
+    cp2k_code, targets, restart_uuid=None, n_nodes=1, n_cores_per_node=1
 ):
     # check if test geometry is already in database
     qb = orm.QueryBuilder()
@@ -75,8 +75,8 @@ def _example_cp2k_replicachain(
 
 
 def example_cp2k_replicachain_rks(cp2k_code):
-    pk1 = _example_cp2k_replicachain(cp2k_code, None)
-    _example_cp2k_replicachain(cp2k_code, pk1)
+    pk1 = _example_cp2k_replicachain(cp2k_code, [1.40, 1.21, 1.87])
+    _example_cp2k_replicachain(cp2k_code, [1.47, 1.27, 1.87], pk1)
 
 
 @click.command("cli")

--- a/examples/workflows/example_cp2k_stm.py
+++ b/examples/workflows/example_cp2k_stm.py
@@ -1,17 +1,26 @@
-import pathlib
-
 import ase.io
 import click
 from aiida import engine, orm, plugins
 
+try:
+    from examples.workflows._paths import script_dir
+except ModuleNotFoundError:
+    from _paths import script_dir
+
 Cp2kStmWorkChain = plugins.WorkflowFactory("nanotech_empa.cp2k.stm")
 
-DATA_DIR = pathlib.Path(__file__).parent.absolute()
+DATA_DIR = script_dir(__file__)
 GEO_FILE = "c2h2_on_au111.xyz"
 
 
 def _example_cp2k_stm(
-    cp2k_code, spm_code, sc_diag, force_multiplicity, uks, n_nodes, n_cores_per_node
+    cp2k_code,
+    spm_code,
+    sc_diag,
+    force_multiplicity,
+    uks,
+    n_nodes=1,
+    n_cores_per_node=1,
 ):
     # Check test geometry is already in database.
     qb = orm.QueryBuilder()
@@ -37,6 +46,9 @@ def _example_cp2k_stm(
     builder.protocol = orm.Str("debug")
 
     if uks:
+        magnetization_per_site = [0 for _ in range(len(structure.sites))]
+        magnetization_per_site[0] = 1
+        magnetization_per_site[1] = -1
         dft_params = {
             "sc_diag": sc_diag,
             "force_multiplicity": force_multiplicity,
@@ -44,9 +56,8 @@ def _example_cp2k_stm(
             "periodic": "XYZ",
             "uks": uks,
             "multiplicity": 1,
+            "magnetization_per_site": magnetization_per_site,
             "smear_t": 150,
-            "spin_up_guess": [0],
-            "spin_dw_guess": [1],
         }
     else:
         dft_params = {

--- a/examples/workflows/example_gaussian_casscf.py
+++ b/examples/workflows/example_gaussian_casscf.py
@@ -6,10 +6,15 @@ from aiida.engine import run_get_node
 from aiida.orm import Bool, Dict, List, Str, StructureData, load_code
 from aiida.plugins import WorkflowFactory
 
+try:
+    from examples.workflows._paths import script_dir
+except ModuleNotFoundError:
+    from _paths import script_dir
+
 GaussianCasscfSeriesWorkChain = WorkflowFactory("nanotech_empa.gaussian.casscf_series")
 
-DATA_DIR = os.path.dirname(os.path.abspath(__file__))
-OUTPUT_DIR = os.path.dirname(os.path.abspath(__file__))
+DATA_DIR = str(script_dir(__file__))
+OUTPUT_DIR = DATA_DIR
 
 
 def _example_gaussian_casscf(gaussian_code, formchk_code, cubegen_code):

--- a/examples/workflows/example_gaussian_nics.py
+++ b/examples/workflows/example_gaussian_nics.py
@@ -1,11 +1,14 @@
-import pathlib
-
 import click
 from aiida import engine, orm, plugins
 from ase.io import read
 
+try:
+    from examples.workflows._paths import script_dir
+except ModuleNotFoundError:
+    from _paths import script_dir
+
 GaussianNicsWorkChain = plugins.WorkflowFactory("nanotech_empa.gaussian.nics")
-DATA_DIR = pathlib.Path(__file__).parent.absolute()
+DATA_DIR = script_dir(__file__)
 GEO_FILE1 = "naphthalene.xyz"
 GEO_FILE2 = "C9H7N.xyz"
 

--- a/examples/workflows/example_gaussian_opt.py
+++ b/examples/workflows/example_gaussian_opt.py
@@ -4,10 +4,15 @@ import ase.io
 import numpy as np
 from aiida import engine, orm, plugins
 
+try:
+    from examples.workflows._paths import script_dir
+except ModuleNotFoundError:
+    from _paths import script_dir
+
 GaussianRelaxWorkChain = plugins.WorkflowFactory("nanotech_empa.gaussian.relax")
 
-DATA_DIR = os.path.dirname(os.path.abspath(__file__))
-OUTPUT_DIR = os.path.dirname(os.path.abspath(__file__))
+DATA_DIR = str(script_dir(__file__))
+OUTPUT_DIR = DATA_DIR
 
 
 def _example_gaussian_spin(gaussian_code):  # , formchk_code, cubegen_code):

--- a/examples/workflows/example_gaussian_spin.py
+++ b/examples/workflows/example_gaussian_spin.py
@@ -8,10 +8,15 @@ from aiida.plugins import WorkflowFactory
 
 import aiida_nanotech_empa.utils.gaussian_wcs_postprocess as pp
 
+try:
+    from examples.workflows._paths import script_dir
+except ModuleNotFoundError:
+    from _paths import script_dir
+
 GaussianSpinWorkChain = WorkflowFactory("nanotech_empa.gaussian.spin")
 
-DATA_DIR = os.path.dirname(os.path.abspath(__file__))
-OUTPUT_DIR = os.path.dirname(os.path.abspath(__file__))
+DATA_DIR = str(script_dir(__file__))
+OUTPUT_DIR = DATA_DIR
 
 
 def _example_gaussian_spin(gaussian_code, formchk_code, cubegen_code):

--- a/examples/workflows/example_nanoribbon.py
+++ b/examples/workflows/example_nanoribbon.py
@@ -1,16 +1,19 @@
-import pathlib
-
 import ase.io
 import click
 from aiida import engine, orm, plugins
 
 from aiida_nanotech_empa.utils.cube_utils import cube_from_qe_pp_arraydata
 
+try:
+    from examples.workflows._paths import script_dir
+except ModuleNotFoundError:
+    from _paths import script_dir
+
 # AiiDA classes.
 NanoribbonWorkChain = plugins.WorkflowFactory("nanotech_empa.nanoribbon")
 
-DATA_DIR = pathlib.Path(__file__).parent.absolute()
-OUTPUT_DIR = pathlib.Path(__file__).parent.absolute()
+DATA_DIR = script_dir(__file__)
+OUTPUT_DIR = DATA_DIR
 
 
 def _example_nanoribbon(


### PR DESCRIPTION
This pull request introduces several improvements and refactorings across workflow files, example scripts, and test configuration. The main themes are improved parameter handling for CP2K workchains, enhanced test and example script usability, and codebase simplification. Notably, the handling of DFT parameters is now more robust and consistent, and example scripts are updated for better path handling and reproducibility.

**Workflow improvements and parameter handling:**

* Added a helper function `geo_opt_dft_params` in `molecule_opt_gw_workchain.py` to consistently generate DFT parameters for geometry optimizations, and refactored both `adsorbed_gw_ic_workchain.py` and `molecule_opt_gw_workchain.py` to use this function, replacing direct parameter assignments with dictionary-based input. The protocol can now be switched to "debug" mode via a new `debug` input. [[1]](diffhunk://#diff-bc0665cf28d91ebb0e5d5b3fe2a24e93ad959dce89520068c9a4a81ba8e9eb92R5) [[2]](diffhunk://#diff-bc0665cf28d91ebb0e5d5b3fe2a24e93ad959dce89520068c9a4a81ba8e9eb92R155-R161) [[3]](diffhunk://#diff-bc0665cf28d91ebb0e5d5b3fe2a24e93ad959dce89520068c9a4a81ba8e9eb92L263-R279) [[4]](diffhunk://#diff-27d769268e4c5c24f1fb944e7b9e55808ba2cd45a9026d5163b04f2ec6dd4651R30-R49) [[5]](diffhunk://#diff-27d769268e4c5c24f1fb944e7b9e55808ba2cd45a9026d5163b04f2ec6dd4651L142-R170)
* Updated downstream workflow calls to propagate the `debug` input, ensuring consistent debug behavior across sub-workflows. [[1]](diffhunk://#diff-bc0665cf28d91ebb0e5d5b3fe2a24e93ad959dce89520068c9a4a81ba8e9eb92R310) [[2]](diffhunk://#diff-bc0665cf28d91ebb0e5d5b3fe2a24e93ad959dce89520068c9a4a81ba8e9eb92R329)
* Fixed the loading of CP2K protocols in `molecule_gw_workchain.py` by switching to the correct utility function.

**Test and example script enhancements:**

* Introduced a `_paths.py` helper to reliably determine script directories, and updated all example scripts to use `script_dir`, improving compatibility with both `pytest` and `verdi run`. [[1]](diffhunk://#diff-02f7b0464fbc5df6a4a04a0ca7ee71c3753ae6183a0e6cc475bcfc38d59e0a51R1-R18) [[2]](diffhunk://#diff-b36836f8758081a5c44a7897cec8787834a6ded7be8a68d4999367e9e6d5b9b3R4-R14) [[3]](diffhunk://#diff-5162e8d712e1fbc5c977631c7a2a03a8f9ba354a96df3caa9ec5ba6338b66d69L1-R32) [[4]](diffhunk://#diff-9a3cf96b160ec6ed100b64a1f382c3f291ebdc0bb126a7512189b8afd367e889L1-R17) [[5]](diffhunk://#diff-e8b8850322143a195c39667cedc36f0b27ffe6706ac941fa90b24ff40948c401L1-R16) [[6]](diffhunk://#diff-426028f90cba953de47e011a52dbc034ddfa381bec112df3677bf25fbd48488fL1-R12) [[7]](diffhunk://#diff-87c982b9dd7bf7064ed78bfd31f36e82902e485cb09302d0f20753b319dd24c7L2-R14) [[8]](diffhunk://#diff-d086b2e5bddbc93d9386b6d560f29dc44a2e62178d10f97341213c3e8bf336f3L1-R12) [[9]](diffhunk://#diff-3df318b447588229d4ccabfddf9e81a841779c9d0c90c135b8c95afe0ab24891L1-R23)
* Updated CP2K example scripts to set default resource values and handle magnetization and multiplicity parameters more robustly, especially for UKS calculations. [[1]](diffhunk://#diff-9a3cf96b160ec6ed100b64a1f382c3f291ebdc0bb126a7512189b8afd367e889R50-R52) [[2]](diffhunk://#diff-9a3cf96b160ec6ed100b64a1f382c3f291ebdc0bb126a7512189b8afd367e889R63-L59) [[3]](diffhunk://#diff-3df318b447588229d4ccabfddf9e81a841779c9d0c90c135b8c95afe0ab24891R49-R51) [[4]](diffhunk://#diff-3df318b447588229d4ccabfddf9e81a841779c9d0c90c135b8c95afe0ab24891R60-L50)
* Changed default values and argument handling in several example scripts for improved usability (e.g., defaulting to 1 node and 1 core per node). [[1]](diffhunk://#diff-5162e8d712e1fbc5c977631c7a2a03a8f9ba354a96df3caa9ec5ba6338b66d69L1-R32) [[2]](diffhunk://#diff-d086b2e5bddbc93d9386b6d560f29dc44a2e62178d10f97341213c3e8bf336f3L176-R179) [[3]](diffhunk://#diff-3df318b447588229d4ccabfddf9e81a841779c9d0c90c135b8c95afe0ab24891L1-R23)

**Test configuration updates:**

* Added a `collect_ignore` list in `conftest.py` to exclude certain example scripts from test collection, and added a fixture for the `ppafm` code. [[1]](diffhunk://#diff-a31c7ed5d35f5ed8233994868c54d625b18e6bacb6794344c4531e62bd9dde59R12-R20) [[2]](diffhunk://#diff-a31c7ed5d35f5ed8233994868c54d625b18e6bacb6794344c4531e62bd9dde59R127-R131)

**Codebase simplification:**

* Removed unnecessary imports (e.g., `typer` in `example_cubehandler.py`) and improved CLI invocation. [[1]](diffhunk://#diff-1ce0116e85d04cf9e413a33fc13ef24edec6cccc2dbd000255768b4756c9bc78L1) [[2]](diffhunk://#diff-1ce0116e85d04cf9e413a33fc13ef24edec6cccc2dbd000255768b4756c9bc78R39-R40)
* Standardized the use of `plugins.DataFactory` over the deprecated `orm.DataFactory` for consistency.

These changes improve workflow flexibility, code maintainability, and the reliability of both tests and example runs.