### PR TITLE
Prepare workflows for AiiDA 2.8 and Python 3.12

### DIFF
--- a/aiida_nanotech_empa/version.py
+++ b/aiida_nanotech_empa/version.py
@@ -1,4 +1,4 @@
 #!/usr/bin/env python
 """This module contains project version information."""
 
-__version__ = "1.0.0b12"
+__version__ = "1.0.0b13"

--- a/aiida_nanotech_empa/workflows/cp2k/afm_workchain.py
+++ b/aiida_nanotech_empa/workflows/cp2k/afm_workchain.py
@@ -6,6 +6,7 @@ from aiida import engine, orm, plugins
 from ...utils import common_utils
 from . import cp2k_utils
 from .diag_workchain import Cp2kDiagWorkChain
+from .geo_opt_workchain import validate_on_unhandled_failure
 
 AfmCalculation = plugins.CalculationFactory("nanotech_empa.afm")
 
@@ -35,6 +36,35 @@ class Cp2kAfmWorkChain(engine.WorkChain):
             help="Define options for the cacluations: walltime, memory, CPUs, etc.",
         )
         spec.input("ppafm_params", valid_type=orm.Dict)
+        spec.input(
+            "max_iterations",
+            valid_type=orm.Int,
+            default=lambda: orm.Int(5),
+            required=False,
+            help="Maximum number of CP2K restart attempts delegated to cp2k.base.",
+        )
+        spec.input(
+            "clean_workdir",
+            valid_type=orm.Bool,
+            default=lambda: orm.Bool(False),
+            required=False,
+            help="Clean called CP2K calculation work directories after termination.",
+        )
+        spec.input(
+            "on_unhandled_failure",
+            valid_type=orm.Str,
+            default=lambda: orm.Str("pause"),
+            required=False,
+            validator=validate_on_unhandled_failure,
+            help="Action for unhandled cp2k.base failures: abort, pause, restart_once, or restart_and_pause.",
+        )
+        spec.input(
+            "pause_on_max_iterations",
+            valid_type=orm.Bool,
+            default=lambda: orm.Bool(True),
+            required=False,
+            help="Pause cp2k.base for inspection when restart max_iterations is reached.",
+        )
 
         spec.outline(
             cls.setup,
@@ -50,6 +80,12 @@ class Cp2kAfmWorkChain(engine.WorkChain):
             "ERROR_TERMINATION",
             message="One or more steps of the work chain failed.",
         )
+
+    def set_restart_policy(self, builder):
+        builder.max_iterations = self.inputs.max_iterations
+        builder.clean_workdir = self.inputs.clean_workdir
+        builder.on_unhandled_failure = self.inputs.on_unhandled_failure
+        builder.pause_on_max_iterations = self.inputs.pause_on_max_iterations
 
     def setup(self):
         self.report("Setting up workchain")
@@ -82,6 +118,7 @@ class Cp2kAfmWorkChain(engine.WorkChain):
         builder.protocol = self.inputs.protocol
         builder.dft_params = orm.Dict(self.ctx.dft_params)
         builder.options = orm.Dict(self.inputs.options)
+        self.set_restart_policy(builder)
 
         # Restart wfn.
         if "parent_calc_folder" in self.inputs:

--- a/aiida_nanotech_empa/workflows/cp2k/diag_workchain.py
+++ b/aiida_nanotech_empa/workflows/cp2k/diag_workchain.py
@@ -6,6 +6,7 @@ from aiida import engine, orm, plugins
 
 from ...utils import common_utils
 from . import cp2k_utils
+from .geo_opt_workchain import validate_on_unhandled_failure
 
 Cp2kBaseWorkChain = plugins.WorkflowFactory("cp2k.base")
 
@@ -44,6 +45,35 @@ class Cp2kDiagWorkChain(engine.WorkChain):
             required=False,
             help="Define options for the cacluations: walltime, memory, CPUs, etc.",
         )
+        spec.input(
+            "max_iterations",
+            valid_type=orm.Int,
+            default=lambda: orm.Int(5),
+            required=False,
+            help="Maximum number of CP2K restart attempts delegated to cp2k.base.",
+        )
+        spec.input(
+            "clean_workdir",
+            valid_type=orm.Bool,
+            default=lambda: orm.Bool(False),
+            required=False,
+            help="Clean called CP2K calculation work directories after termination.",
+        )
+        spec.input(
+            "on_unhandled_failure",
+            valid_type=orm.Str,
+            default=lambda: orm.Str("pause"),
+            required=False,
+            validator=validate_on_unhandled_failure,
+            help="Action for unhandled cp2k.base failures: abort, pause, restart_once, or restart_and_pause.",
+        )
+        spec.input(
+            "pause_on_max_iterations",
+            valid_type=orm.Bool,
+            default=lambda: orm.Bool(True),
+            required=False,
+            help="Pause cp2k.base for inspection when restart max_iterations is reached.",
+        )
         spec.outline(
             cls.setup,
             cls.run_ot_scf,
@@ -58,6 +88,12 @@ class Cp2kDiagWorkChain(engine.WorkChain):
             "ERROR_TERMINATION",
             message="One or more steps of the work chain failed.",
         )
+
+    def set_restart_policy(self, builder):
+        builder.max_iterations = self.inputs.max_iterations
+        builder.clean_workdir = self.inputs.clean_workdir
+        builder.on_unhandled_failure = self.inputs.on_unhandled_failure
+        builder.pause_on_max_iterations = self.inputs.pause_on_max_iterations
 
     def setup(self):
         self.report("Setting up workchain")
@@ -121,6 +157,7 @@ class Cp2kDiagWorkChain(engine.WorkChain):
         # Set workflow inputs.
         builder = Cp2kBaseWorkChain.get_builder()
         builder.cp2k.code = self.inputs.cp2k_code
+        self.set_restart_policy(builder)
         builder.cp2k.structure = orm.StructureData(ase=self.ctx.structure_with_tags)
 
         builder.cp2k.file = self.ctx.files
@@ -249,6 +286,7 @@ class Cp2kDiagWorkChain(engine.WorkChain):
 
         builder = Cp2kBaseWorkChain.get_builder()
         builder.cp2k.code = self.inputs.cp2k_code
+        self.set_restart_policy(builder)
         builder.cp2k.structure = orm.StructureData(ase=self.ctx.structure_with_tags)
 
         builder.cp2k.file = self.ctx.files

--- a/aiida_nanotech_empa/workflows/cp2k/fragment_separation.py
+++ b/aiida_nanotech_empa/workflows/cp2k/fragment_separation.py
@@ -4,6 +4,7 @@ from aiida import engine, orm, plugins
 
 from ...utils import common_utils, split_structure, string_utils
 from . import cp2k_utils
+from .geo_opt_workchain import validate_on_unhandled_failure
 
 StructureData = plugins.DataFactory("core.structure")
 Cp2kBaseWorkChain = plugins.WorkflowFactory("cp2k.base")
@@ -74,6 +75,35 @@ class Cp2kFragmentSeparationWorkChain(engine.WorkChain):
             required=False,
             help="Define options for the cacluations: walltime, memory, CPUs, etc.",
         )
+        spec.input(
+            "max_iterations",
+            valid_type=orm.Int,
+            default=lambda: orm.Int(5),
+            required=False,
+            help="Maximum number of CP2K restart attempts delegated to cp2k.base.",
+        )
+        spec.input(
+            "clean_workdir",
+            valid_type=orm.Bool,
+            default=lambda: orm.Bool(False),
+            required=False,
+            help="Clean called CP2K calculation work directories after termination.",
+        )
+        spec.input(
+            "on_unhandled_failure",
+            valid_type=orm.Str,
+            default=lambda: orm.Str("pause"),
+            required=False,
+            validator=validate_on_unhandled_failure,
+            help="Action for unhandled cp2k.base failures: abort, pause, restart_once, or restart_and_pause.",
+        )
+        spec.input(
+            "pause_on_max_iterations",
+            valid_type=orm.Bool,
+            default=lambda: orm.Bool(True),
+            required=False,
+            help="Pause cp2k.base for inspection when restart max_iterations is reached.",
+        )
 
         # in case wfn for the whole system is available and matches uks/rks parameters
         spec.input("parent_calc_folder", valid_type=orm.RemoteData, required=False)
@@ -101,6 +131,12 @@ class Cp2kFragmentSeparationWorkChain(engine.WorkChain):
 
     def should_run_cubehandler(self):
         return "cubehandler_code" in self.inputs
+
+    def set_restart_policy(self, builder):
+        builder.max_iterations = self.inputs.max_iterations
+        builder.clean_workdir = self.inputs.clean_workdir
+        builder.on_unhandled_failure = self.inputs.on_unhandled_failure
+        builder.pause_on_max_iterations = self.inputs.pause_on_max_iterations
 
     def setup(self):
         """Setup the work chain."""
@@ -158,6 +194,7 @@ class Cp2kFragmentSeparationWorkChain(engine.WorkChain):
             # Generic inputs that are always the same.
             builder = Cp2kBaseWorkChain.get_builder()
             builder.cp2k.code = self.inputs.code
+            self.set_restart_policy(builder)
             builder.cp2k.metadata.options.parser_name = "cp2k_advanced_parser"
 
             # restart wfn in case of fragment 'all'
@@ -241,6 +278,7 @@ class Cp2kFragmentSeparationWorkChain(engine.WorkChain):
             # Generic inputs that are always the same.
             builder = Cp2kBaseWorkChain.get_builder()
             builder.cp2k.code = self.inputs.code
+            self.set_restart_policy(builder)
             builder.cp2k.metadata.options = self.inputs.options[fragment]
             builder.cp2k.file = self.ctx.file
             builder.cp2k.metadata.options.parser_name = "cp2k_advanced_parser"

--- a/aiida_nanotech_empa/workflows/cp2k/geo_opt_workchain.py
+++ b/aiida_nanotech_empa/workflows/cp2k/geo_opt_workchain.py
@@ -9,6 +9,21 @@ from . import cp2k_utils
 Cp2kBaseWorkChain = plugins.WorkflowFactory("cp2k.base")
 CubeHandlerCalculation = plugins.CalculationFactory("nanotech_empa.cubehandler")
 
+ON_UNHANDLED_FAILURE_ACTIONS = ("abort", "pause", "restart_once", "restart_and_pause")
+
+
+def validate_on_unhandled_failure(value, _):
+    if value is None:
+        return None
+
+    if value.value not in ON_UNHANDLED_FAILURE_ACTIONS:
+        return (
+            f"on_unhandled_failure: {value.value!r}. Must be one of: "
+            f"{', '.join(ON_UNHANDLED_FAILURE_ACTIONS)}"
+        )
+
+    return None
+
 
 class Cp2kGeoOptWorkChain(engine.WorkChain):
     @classmethod
@@ -32,6 +47,35 @@ class Cp2kGeoOptWorkChain(engine.WorkChain):
             valid_type=dict,
             non_db=True,
             help="Define options for the cacluations: walltime, memory, CPUs, etc.",
+        )
+        spec.input(
+            "max_iterations",
+            valid_type=orm.Int,
+            default=lambda: orm.Int(5),
+            required=False,
+            help="Maximum number of CP2K restart attempts delegated to cp2k.base.",
+        )
+        spec.input(
+            "clean_workdir",
+            valid_type=orm.Bool,
+            default=lambda: orm.Bool(False),
+            required=False,
+            help="Clean called CP2K calculation work directories after termination.",
+        )
+        spec.input(
+            "on_unhandled_failure",
+            valid_type=orm.Str,
+            default=lambda: orm.Str("pause"),
+            required=False,
+            validator=validate_on_unhandled_failure,
+            help="Action for unhandled cp2k.base failures: abort, pause, restart_once, or restart_and_pause.",
+        )
+        spec.input(
+            "pause_on_max_iterations",
+            valid_type=orm.Bool,
+            default=lambda: orm.Bool(True),
+            required=False,
+            help="Pause cp2k.base for inspection when restart max_iterations is reached.",
         )
 
         # Workchain outline.
@@ -186,8 +230,16 @@ class Cp2kGeoOptWorkChain(engine.WorkChain):
         # Parser.
         builder.cp2k.metadata.options.parser_name = "cp2k_advanced_parser"
 
+        # Restart policy.
+        builder.max_iterations = self.inputs.max_iterations
+        builder.clean_workdir = self.inputs.clean_workdir
+        builder.on_unhandled_failure = self.inputs.on_unhandled_failure
+        builder.pause_on_max_iterations = self.inputs.pause_on_max_iterations
+
         # Handlers.
-        builder.handler_overrides = orm.Dict({"restart_incomplete_calculation": True})
+        builder.handler_overrides = orm.Dict(
+            {"restart_incomplete_calculation": {"enabled": True}}
+        )
 
         # Restart wfn.
         if "parent_calc_folder" in self.inputs:

--- a/aiida_nanotech_empa/workflows/cp2k/orbitals_workchain.py
+++ b/aiida_nanotech_empa/workflows/cp2k/orbitals_workchain.py
@@ -2,6 +2,7 @@ import numpy as np
 from aiida import engine, orm, plugins
 
 from ...utils import common_utils
+from .geo_opt_workchain import validate_on_unhandled_failure
 
 Cp2kDiagWorkChain = plugins.WorkflowFactory("nanotech_empa.cp2k.diag")
 StmCalculation = plugins.CalculationFactory("nanotech_empa.stm")
@@ -36,6 +37,35 @@ class Cp2kOrbitalsWorkChain(engine.WorkChain):
             non_db=True,
             help="Define options for the cacluations: walltime, memory, CPUs, etc.",
         )
+        spec.input(
+            "max_iterations",
+            valid_type=orm.Int,
+            default=lambda: orm.Int(5),
+            required=False,
+            help="Maximum number of CP2K restart attempts delegated to cp2k.base.",
+        )
+        spec.input(
+            "clean_workdir",
+            valid_type=orm.Bool,
+            default=lambda: orm.Bool(False),
+            required=False,
+            help="Clean called CP2K calculation work directories after termination.",
+        )
+        spec.input(
+            "on_unhandled_failure",
+            valid_type=orm.Str,
+            default=lambda: orm.Str("pause"),
+            required=False,
+            validator=validate_on_unhandled_failure,
+            help="Action for unhandled cp2k.base failures: abort, pause, restart_once, or restart_and_pause.",
+        )
+        spec.input(
+            "pause_on_max_iterations",
+            valid_type=orm.Bool,
+            default=lambda: orm.Bool(True),
+            required=False,
+            help="Pause cp2k.base for inspection when restart max_iterations is reached.",
+        )
 
         spec.outline(
             cls.setup,
@@ -55,6 +85,12 @@ class Cp2kOrbitalsWorkChain(engine.WorkChain):
             message="One or more steps of the work chain failed.",
         )
 
+    def set_restart_policy(self, builder):
+        builder.max_iterations = self.inputs.max_iterations
+        builder.clean_workdir = self.inputs.clean_workdir
+        builder.on_unhandled_failure = self.inputs.on_unhandled_failure
+        builder.pause_on_max_iterations = self.inputs.pause_on_max_iterations
+
     def setup(self):
         self.report("Setting up workchain")
         n_lumo = int(self.inputs.spm_params.get_dict()["--n_lumo"])
@@ -66,6 +102,7 @@ class Cp2kOrbitalsWorkChain(engine.WorkChain):
         self.report("Running CP2K diagonalization SCF")
         builder = Cp2kDiagWorkChain.get_builder()
         builder.cp2k_code = self.inputs.cp2k_code
+        self.set_restart_policy(builder)
         builder.structure = self.inputs.structure
         builder.dft_params = orm.Dict(self.ctx.dft_params)
         builder.protocol = self.inputs.protocol

--- a/aiida_nanotech_empa/workflows/cp2k/pdos_workchain.py
+++ b/aiida_nanotech_empa/workflows/cp2k/pdos_workchain.py
@@ -5,6 +5,7 @@ from aiida import engine, orm, plugins
 
 from ...utils import common_utils, split_structure
 from . import cp2k_utils
+from .geo_opt_workchain import validate_on_unhandled_failure
 
 Cp2kDiagWorkChain = plugins.WorkflowFactory("nanotech_empa.cp2k.diag")
 OverlapCalculation = plugins.CalculationFactory("nanotech_empa.overlap")
@@ -51,6 +52,35 @@ class Cp2kPdosWorkChain(engine.WorkChain):
             non_db=True,
             help="Define options for the cacluations: walltime, memory, CPUs, etc.",
         )
+        spec.input(
+            "max_iterations",
+            valid_type=orm.Int,
+            default=lambda: orm.Int(5),
+            required=False,
+            help="Maximum number of CP2K restart attempts delegated to cp2k.base.",
+        )
+        spec.input(
+            "clean_workdir",
+            valid_type=orm.Bool,
+            default=lambda: orm.Bool(False),
+            required=False,
+            help="Clean called CP2K calculation work directories after termination.",
+        )
+        spec.input(
+            "on_unhandled_failure",
+            valid_type=orm.Str,
+            default=lambda: orm.Str("pause"),
+            required=False,
+            validator=validate_on_unhandled_failure,
+            help="Action for unhandled cp2k.base failures: abort, pause, restart_once, or restart_and_pause.",
+        )
+        spec.input(
+            "pause_on_max_iterations",
+            valid_type=orm.Bool,
+            default=lambda: orm.Bool(True),
+            required=False,
+            help="Pause cp2k.base for inspection when restart max_iterations is reached.",
+        )
 
         spec.outline(
             cls.setup,
@@ -68,6 +98,12 @@ class Cp2kPdosWorkChain(engine.WorkChain):
             "ERROR_TERMINATION",
             message="One or more steps of the work chain failed.",
         )
+
+    def set_restart_policy(self, builder):
+        builder.max_iterations = self.inputs.max_iterations
+        builder.clean_workdir = self.inputs.clean_workdir
+        builder.on_unhandled_failure = self.inputs.on_unhandled_failure
+        builder.pause_on_max_iterations = self.inputs.pause_on_max_iterations
 
     def setup(self):
         self.report("Setting up workchain")
@@ -127,6 +163,7 @@ class Cp2kPdosWorkChain(engine.WorkChain):
         self.report("Running Diag Workchain for the full system.")
         builder = Cp2kDiagWorkChain.get_builder()
         builder.cp2k_code = self.inputs.cp2k_code
+        self.set_restart_policy(builder)
         builder.structure = self.ctx.structure
         builder.protocol = self.inputs.protocol
         builder.dft_params = orm.Dict(self.ctx.dft_parameters)
@@ -148,6 +185,7 @@ class Cp2kPdosWorkChain(engine.WorkChain):
             self.report("Running Diag Workchain for the fragment.")
             builder = Cp2kDiagWorkChain.get_builder()
             builder.cp2k_code = self.inputs.cp2k_code
+            self.set_restart_policy(builder)
             builder.structure = self.ctx.molecule_structure
             builder.protocol = self.inputs.protocol
             builder.dft_params = orm.Dict(self.ctx.mol_dft_parameters)

--- a/aiida_nanotech_empa/workflows/cp2k/phonons_workchain.py
+++ b/aiida_nanotech_empa/workflows/cp2k/phonons_workchain.py
@@ -4,6 +4,7 @@ from aiida import engine, orm, plugins
 
 from ...utils import common_utils
 from . import cp2k_utils
+from .geo_opt_workchain import validate_on_unhandled_failure
 
 Cp2kGeoOptWorkChain = plugins.WorkflowFactory("nanotech_empa.cp2k.geo_opt")
 Cp2kCalculation = plugins.CalculationFactory("cp2k")
@@ -32,6 +33,35 @@ class Cp2kPhononsWorkChain(engine.WorkChain):
             non_db=True,
             help="Define options for the cacluations: walltime, memory, CPUs, etc.",
         )
+        spec.input(
+            "max_iterations",
+            valid_type=orm.Int,
+            default=lambda: orm.Int(5),
+            required=False,
+            help="Maximum number of CP2K restart attempts delegated to cp2k.base.",
+        )
+        spec.input(
+            "clean_workdir",
+            valid_type=orm.Bool,
+            default=lambda: orm.Bool(False),
+            required=False,
+            help="Clean called CP2K calculation work directories after termination.",
+        )
+        spec.input(
+            "on_unhandled_failure",
+            valid_type=orm.Str,
+            default=lambda: orm.Str("pause"),
+            required=False,
+            validator=validate_on_unhandled_failure,
+            help="Action for unhandled cp2k.base failures: abort, pause, restart_once, or restart_and_pause.",
+        )
+        spec.input(
+            "pause_on_max_iterations",
+            valid_type=orm.Bool,
+            default=lambda: orm.Bool(True),
+            required=False,
+            help="Pause cp2k.base for inspection when restart max_iterations is reached.",
+        )
 
         spec.outline(
             cls.setup,
@@ -46,6 +76,12 @@ class Cp2kPhononsWorkChain(engine.WorkChain):
             "ERROR_TERMINATION",
             message="One or more steps of the work chain failed.",
         )
+
+    def set_restart_policy(self, builder):
+        builder.max_iterations = self.inputs.max_iterations
+        builder.clean_workdir = self.inputs.clean_workdir
+        builder.on_unhandled_failure = self.inputs.on_unhandled_failure
+        builder.pause_on_max_iterations = self.inputs.pause_on_max_iterations
 
     def setup(self):
         self.report("Inspecting input and setting up things")
@@ -108,6 +144,7 @@ class Cp2kPhononsWorkChain(engine.WorkChain):
 
         builder.code = self.inputs.code
         builder.structure = self.inputs.structure
+        self.set_restart_policy(builder)
 
         # Restart WFN.
         if "parent_calc_folder" in self.inputs:

--- a/aiida_nanotech_empa/workflows/cp2k/replica_workchain.py
+++ b/aiida_nanotech_empa/workflows/cp2k/replica_workchain.py
@@ -5,6 +5,7 @@ from aiida import engine, orm, plugins
 
 from ...utils import common_utils
 from . import cp2k_utils
+from .geo_opt_workchain import validate_on_unhandled_failure
 
 Cp2kBaseWorkChain = plugins.WorkflowFactory("cp2k.base")
 Cp2kCalculation = plugins.CalculationFactory("cp2k")
@@ -38,6 +39,35 @@ class Cp2kReplicaWorkChain(engine.WorkChain):
             non_db=True,
             help="Define options for the cacluations: walltime, memory, CPUs, etc.",
         )
+        spec.input(
+            "max_iterations",
+            valid_type=orm.Int,
+            default=lambda: orm.Int(5),
+            required=False,
+            help="Maximum number of CP2K restart attempts delegated to cp2k.base.",
+        )
+        spec.input(
+            "clean_workdir",
+            valid_type=orm.Bool,
+            default=lambda: orm.Bool(False),
+            required=False,
+            help="Clean called CP2K calculation work directories after termination.",
+        )
+        spec.input(
+            "on_unhandled_failure",
+            valid_type=orm.Str,
+            default=lambda: orm.Str("pause"),
+            required=False,
+            validator=validate_on_unhandled_failure,
+            help="Action for unhandled cp2k.base failures: abort, pause, restart_once, or restart_and_pause.",
+        )
+        spec.input(
+            "pause_on_max_iterations",
+            valid_type=orm.Bool,
+            default=lambda: orm.Bool(True),
+            required=False,
+            help="Pause cp2k.base for inspection when restart max_iterations is reached.",
+        )
 
         spec.outline(
             cls.setup,
@@ -61,6 +91,12 @@ class Cp2kReplicaWorkChain(engine.WorkChain):
         spec.output_namespace("structures", valid_type=orm.StructureData)
         spec.output_namespace("details", valid_type=orm.Dict)
         spec.exit_code(390, "ERROR_TERMINATION", message="One geo opt failed")
+
+    def set_restart_policy(self, builder):
+        builder.max_iterations = self.inputs.max_iterations
+        builder.clean_workdir = self.inputs.clean_workdir
+        builder.on_unhandled_failure = self.inputs.on_unhandled_failure
+        builder.pause_on_max_iterations = self.inputs.pause_on_max_iterations
 
     def setup(self):
         """Initialize the workchain process."""
@@ -234,13 +270,14 @@ class Cp2kReplicaWorkChain(engine.WorkChain):
                 structure = self.ctx.lowest_energy_structure
 
                 files, input_dict, structure_with_tags = cp2k_utils.get_dft_inputs(
-                    self.inputs.dft_params,
+                    self.inputs.dft_params.get_dict(),
                     structure,
                     "geo_opt_protocol.yml",
                     self.inputs.protocol.value,
                 )
 
                 builder = Cp2kBaseWorkChain.get_builder()
+                self.set_restart_policy(builder)
                 builder.cp2k.code = self.inputs.code
                 builder.cp2k.structure = orm.StructureData(ase=structure_with_tags)
                 builder.cp2k.file = files

--- a/aiida_nanotech_empa/workflows/cp2k/stm_workchain.py
+++ b/aiida_nanotech_empa/workflows/cp2k/stm_workchain.py
@@ -2,6 +2,7 @@ import numpy as np
 from aiida import engine, orm, plugins
 
 from ...utils import common_utils
+from .geo_opt_workchain import validate_on_unhandled_failure
 
 Cp2kDiagWorkChain = plugins.WorkflowFactory("nanotech_empa.cp2k.diag")
 StmCalculation = plugins.CalculationFactory("nanotech_empa.stm")
@@ -31,6 +32,35 @@ class Cp2kStmWorkChain(engine.WorkChain):
             non_db=True,
             help="Define options for the cacluations: walltime, memory, CPUs, etc.",
         )
+        spec.input(
+            "max_iterations",
+            valid_type=orm.Int,
+            default=lambda: orm.Int(5),
+            required=False,
+            help="Maximum number of CP2K restart attempts delegated to cp2k.base.",
+        )
+        spec.input(
+            "clean_workdir",
+            valid_type=orm.Bool,
+            default=lambda: orm.Bool(False),
+            required=False,
+            help="Clean called CP2K calculation work directories after termination.",
+        )
+        spec.input(
+            "on_unhandled_failure",
+            valid_type=orm.Str,
+            default=lambda: orm.Str("pause"),
+            required=False,
+            validator=validate_on_unhandled_failure,
+            help="Action for unhandled cp2k.base failures: abort, pause, restart_once, or restart_and_pause.",
+        )
+        spec.input(
+            "pause_on_max_iterations",
+            valid_type=orm.Bool,
+            default=lambda: orm.Bool(True),
+            required=False,
+            help="Pause cp2k.base for inspection when restart max_iterations is reached.",
+        )
 
         spec.outline(
             cls.setup,
@@ -46,6 +76,12 @@ class Cp2kStmWorkChain(engine.WorkChain):
             "ERROR_TERMINATION",
             message="One or more steps of the work chain failed.",
         )
+
+    def set_restart_policy(self, builder):
+        builder.max_iterations = self.inputs.max_iterations
+        builder.clean_workdir = self.inputs.clean_workdir
+        builder.on_unhandled_failure = self.inputs.on_unhandled_failure
+        builder.pause_on_max_iterations = self.inputs.pause_on_max_iterations
 
     def setup(self):
         self.report("Setting up workchain")
@@ -64,6 +100,7 @@ class Cp2kStmWorkChain(engine.WorkChain):
         builder.protocol = self.inputs.protocol
         builder.dft_params = orm.Dict(self.ctx.dft_params)
         builder.options = orm.Dict(self.inputs.options)
+        self.set_restart_policy(builder)
 
         # Restart wfn, if requested.
         if "parent_calc_folder" in self.inputs:

--- a/aiida_nanotech_empa/workflows/qe/nanoribbon.py
+++ b/aiida_nanotech_empa/workflows/qe/nanoribbon.py
@@ -37,9 +37,9 @@ class NanoribbonWorkChain(engine.WorkChain):
             default=lambda: orm.Int(3600),
             required=False,
         )
-        spec.input("pw_code", valid_type=orm.Code)
-        spec.input("pp_code", valid_type=orm.Code)
-        spec.input("projwfc_code", valid_type=orm.Code)
+        spec.input("pw_code", valid_type=orm.AbstractCode)
+        spec.input("pp_code", valid_type=orm.AbstractCode)
+        spec.input("projwfc_code", valid_type=orm.AbstractCode)
         spec.input("structure", valid_type=orm.StructureData)
         spec.input(
             "tot_charge",
@@ -219,7 +219,7 @@ class NanoribbonWorkChain(engine.WorkChain):
             "resources": {
                 "num_machines": int(nnodes),
                 "num_mpiprocs_per_machine": self.ctx.nproc_mach,
-                "num_cores_per_mpiproc":1,
+                "num_cores_per_mpiproc": 1,
             },
             "max_wallclock_seconds": 1800,  # 30 minutes
             "withmpi": True,
@@ -293,7 +293,7 @@ class NanoribbonWorkChain(engine.WorkChain):
             "resources": {
                 "num_machines": int(nnodes),
                 "num_mpiprocs_per_machine": nproc_mach,
-                "num_cores_per_mpiproc":1,
+                "num_cores_per_mpiproc": 1,
             },
             "max_wallclock_seconds": self.inputs.wall_seconds.value,  # default 1 hour, max 24 hours
             "withmpi": True,
@@ -373,7 +373,7 @@ class NanoribbonWorkChain(engine.WorkChain):
             "resources": {
                 "num_machines": int(nnodes),
                 "num_mpiprocs_per_machine": self.ctx.nproc_mach,
-                "num_cores_per_mpiproc":1,
+                "num_cores_per_mpiproc": 1,
             },
             "max_wallclock_seconds": int(
                 self.inputs.wall_seconds.value / 24 * nhours
@@ -478,7 +478,7 @@ class NanoribbonWorkChain(engine.WorkChain):
             "resources": {
                 "num_machines": int(nnodes),
                 "num_mpiprocs_per_machine": self.ctx.nproc_mach,
-                "num_cores_per_mpiproc":1,
+                "num_cores_per_mpiproc": 1,
             },
             "max_wallclock_seconds": 30 * 60,  # 30 minutes
             "withmpi": True,
@@ -562,7 +562,7 @@ class NanoribbonWorkChain(engine.WorkChain):
 
         natoms = len(structure.sites)
         max_npools = spinpools * min(1 + int(nkpoints / 4), int(6))
-        max_npools = min(self.ctx.nproc_mach, max_npools) #added for daint.alps
+        max_npools = min(self.ctx.nproc_mach, max_npools)  # added for daint.alps
         nnodes_base = min(max_nodes, (1 + int(natoms / mem_node)))
 
         guess_nnodes = max_npools * nnodes_base
@@ -587,7 +587,7 @@ class NanoribbonWorkChain(engine.WorkChain):
             "resources": {
                 "num_machines": int(nnodes),
                 "num_mpiprocs_per_machine": self.ctx.nproc_mach,
-                "num_cores_per_mpiproc":1,
+                "num_cores_per_mpiproc": 1,
             },
             "withmpi": True,
             "max_wallclock_seconds": wallseconds,

--- a/examples/workflows/example_nanoribbon.py
+++ b/examples/workflows/example_nanoribbon.py
@@ -39,8 +39,8 @@ def _example_nanoribbon(
     builder.structure = orm.StructureData(ase=ase.io.read(geo_file))
     # builder.pseudo_family = orm.Str("SSSP_modified")
     builder.pseudo_family = orm.Str(
-        "SSSP/1.2/PBE/efficiency"
-    )  # It requires aiida-pseudo install sssp!
+        "SSSP/1.3/PBE/precision"
+    )  # It requires: aiida-pseudo install sssp --functional PBE --version 1.3 -p precision
 
     # Metadata
     builder.metadata = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    "aiida-core>=2.6,<2.8",
+    "aiida-core>=2.8,<3.0.0",
     "aiida-quantumespresso~=4.8",
     "aiida-pseudo~=1.7",
     "aiida-cp2k>=2.1.1,<3.0.0",
@@ -94,7 +94,7 @@ dev = [
 slurm_ethz_euler = "aiida_nanotech_empa.schedulers:ETHZEulerSlurmScheduler"
 
 [tool.bumpver]
-current_version = "v1.0.0b12"
+current_version = "v1.0.0b13"
 version_pattern = "vMAJOR.MINOR.PATCH[PYTAGNUM]"
 commit_message = "Bump version {old_version} -> {new_version}."
 commit = true


### PR DESCRIPTION
Draft compatibility PR for the upcoming AiiDAlab Python 3.12 / AiiDA core 2.8 stack.

Summary:
- relax package metadata for `aiida-core>=2.8,<3` and bump the package version to `1.0.0b13`
- expose restart-policy inputs for the CP2K workflow paths touched during the porting pass
- accept AiiDA 2.8 `InstalledCode` / `AbstractCode` inputs in the nanoribbon workflow
- update the nanoribbon example to use the installed app-era pseudo family `SSSP/1.3/PBE/precision`

Local verification performed in the dev container:
- editable install succeeded earlier in the porting pass
- workflow/plugin factories load under AiiDA 2.8
- nanoribbon workflow builder accepts the registered QE `InstalledCode`s
- `example_nanoribbon.py` compiles after the pseudo-family update

Still draft while we continue runtime testing of the workflows in the full Python 3.12 AiiDAlab stack.