### PR TITLE
Add CP2K SCF overlap and Bader workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,18 +5,31 @@
 
 # aiida-nanotech-empa
 
-AiiDA library containing plugins/workflows developed at nanotech@surfaces group from Empa.
+AiiDA library containing plugins, parsers, and workflows developed by the nanotech@surfaces group at Empa.
 
-Contents:
+The package focuses on automation around CP2K, Gaussian, Quantum ESPRESSO, and post-processing tools used in surface-science workflows. It is also used by the `aiidalab-empa-surfaces` app.
 
-* `nanotech_empa.nanoribbon`: work chain to characterize 1D periodic systems based on Quantum Espresso.
+## Contents
 
-* `nanotech_empa.gaussian.spin`: Work chain to characterize spin properties of molecular systems with Gaussian. Calls multiple child work chains. Steps:
-  * Wavefunction stability is tested for each spin multiplicity
-  * Geometry is relaxed for the different spin states and ground state is found
-  * Property calcuation on the ground state: ionization potential and electron affinity with Δ-SCF, natural orbital analysis in case of open-shell singlet
-  * Vertical excitation energies for non-ground state multiplicities
-  * Orbitals and densities are rendered with PyMOL (needs to be installed separately as a python library, e.g. from [pymol-open-source](https://github.com/schrodinger/pymol-open-source/tree/v2.4.0))
+### CP2K workflows
+
+* `nanotech_empa.cp2k.geo_opt`: CP2K geometry and cell optimization workflows with restart handling and optional cube post-processing.
+* `nanotech_empa.cp2k.scf`: single-point CP2K SCF workflow. It can run an OT-only energy calculation, an optional diagonalization step for empty states and AO overlap matrices, sparse AO-overlap retrieval, or Bader charge analysis from a fine charge-density cube.
+* `nanotech_empa.cp2k.diag`: OT plus diagonalization SCF workflow used by STM/PDOS-style workflows and by the SCF workflow.
+* `nanotech_empa.cp2k.stm`, `nanotech_empa.cp2k.afm`, `nanotech_empa.cp2k.hrstm`, `nanotech_empa.cp2k.orbitals`, `nanotech_empa.cp2k.pdos`: workflows for scanning-probe simulations, orbital cubes, and projected density of states.
+* `nanotech_empa.cp2k.fragment_separation`, `nanotech_empa.cp2k.replica`, `nanotech_empa.cp2k.neb`, `nanotech_empa.cp2k.phonons`: workflows for adsorption energies, replica chains, nudged elastic band calculations, and phonons.
+* `nanotech_empa.cp2k.ads_gw_ic`, `nanotech_empa.cp2k.molecule_gw`, `nanotech_empa.cp2k.mol_opt_gw`: CP2K/GW-oriented workflows.
+
+### Calculation plugins
+
+* `nanotech_empa.bader`: runs Bader charge analysis and retrieves `ACF.dat`, `AVF.dat`, and `BCF.dat`.
+* `nanotech_empa.sparse_overlap`: converts CP2K AO overlap matrix logs to sparse `.npz` files using an external converter executable.
+* `nanotech_empa.stm`, `nanotech_empa.overlap`, `nanotech_empa.afm`, `nanotech_empa.hrstm`, `nanotech_empa.cubehandler`: post-processing plugins used by the CP2K workflows.
+
+### Gaussian and Quantum ESPRESSO workflows
+
+* `nanotech_empa.gaussian.*`: Gaussian workflows for SCF, relaxations, spin-state analysis, constrained optimization, CASSCF, NICS, and related post-processing.
+* `nanotech_empa.nanoribbon`: workflow to characterize 1D periodic systems with Quantum ESPRESSO.
 
 ## Installation
 

--- a/aiida_nanotech_empa/plugins/__init__.py
+++ b/aiida_nanotech_empa/plugins/__init__.py
@@ -5,10 +5,12 @@ from .hrstm import HrstmCalculation
 from .overlap import OverlapCalculation
 from .sparse_overlap import SparseOverlapCalculation
 from .stm import StmCalculation
+from .unfolding import Cp2kUnfoldingCalculation
 
 __all__ = (
     "AfmCalculation",
     "BaderCalculation",
+    "Cp2kUnfoldingCalculation",
     "CubeHandlerCalculation",
     "HrstmCalculation",
     "OverlapCalculation",

--- a/aiida_nanotech_empa/plugins/__init__.py
+++ b/aiida_nanotech_empa/plugins/__init__.py
@@ -1,4 +1,5 @@
 from .afm import AfmCalculation
+from .bader import BaderCalculation
 from .cubehandler import CubeHandlerCalculation
 from .hrstm import HrstmCalculation
 from .overlap import OverlapCalculation
@@ -7,6 +8,7 @@ from .stm import StmCalculation
 
 __all__ = (
     "AfmCalculation",
+    "BaderCalculation",
     "CubeHandlerCalculation",
     "HrstmCalculation",
     "OverlapCalculation",

--- a/aiida_nanotech_empa/plugins/__init__.py
+++ b/aiida_nanotech_empa/plugins/__init__.py
@@ -2,6 +2,7 @@ from .afm import AfmCalculation
 from .cubehandler import CubeHandlerCalculation
 from .hrstm import HrstmCalculation
 from .overlap import OverlapCalculation
+from .sparse_overlap import SparseOverlapCalculation
 from .stm import StmCalculation
 
 __all__ = (
@@ -9,5 +10,6 @@ __all__ = (
     "CubeHandlerCalculation",
     "HrstmCalculation",
     "OverlapCalculation",
+    "SparseOverlapCalculation",
     "StmCalculation",
 )

--- a/aiida_nanotech_empa/plugins/bader.py
+++ b/aiida_nanotech_empa/plugins/bader.py
@@ -1,0 +1,64 @@
+from aiida import common, engine, orm
+
+
+DEFAULT_CHARGE_DENSITY_FILENAME = "aiida-ELECTRON_DENSITY-1_0.cube"
+DEFAULT_RETRIEVE_LIST = ["ACF.dat", "AVF.dat", "BCF.dat"]
+
+
+class BaderCalculation(engine.CalcJob):
+    @classmethod
+    def define(cls, spec):
+        super().define(spec)
+        spec.input(
+            "parent_calc_folder",
+            valid_type=orm.RemoteData,
+            help="CP2K folder containing the charge-density cube.",
+        )
+        spec.input(
+            "charge_density_filename",
+            valid_type=orm.Str,
+            default=lambda: orm.Str(DEFAULT_CHARGE_DENSITY_FILENAME),
+            required=False,
+        )
+        spec.input(
+            "settings",
+            valid_type=orm.Dict,
+            default=lambda: orm.Dict(dict={}),
+            required=False,
+        )
+        spec.input("metadata.options.withmpi", valid_type=bool, default=False)
+
+    def prepare_for_submission(self, folder):
+        settings = self.inputs.settings.get_dict() if "settings" in self.inputs else {}
+
+        codeinfo = common.CodeInfo()
+        codeinfo.code_uuid = self.inputs.code.uuid
+        codeinfo.cmdline_params = [
+            "parent_calc_folder/" + self.inputs.charge_density_filename.value,
+        ]
+
+        calcinfo = common.CalcInfo()
+        calcinfo.uuid = self.uuid
+        calcinfo.codes_info = [codeinfo]
+        calcinfo.remote_symlink_list = []
+        calcinfo.remote_copy_list = []
+        calcinfo.local_copy_list = []
+        calcinfo.retrieve_list = settings.pop(
+            "additional_retrieve_list", DEFAULT_RETRIEVE_LIST
+        )
+
+        comp_uuid = self.inputs.parent_calc_folder.computer.uuid
+        remote_path = self.inputs.parent_calc_folder.get_remote_path()
+        copy_info = (comp_uuid, remote_path, "parent_calc_folder/")
+        if self.inputs.code.computer.uuid == comp_uuid:
+            calcinfo.remote_symlink_list.append(copy_info)
+        else:
+            calcinfo.remote_copy_list.append(copy_info)
+
+        if settings:
+            raise common.InputValidationError(
+                "The following keys have been found in settings but were not understood: "
+                + ",".join(settings.keys())
+            )
+
+        return calcinfo

--- a/aiida_nanotech_empa/plugins/bader.py
+++ b/aiida_nanotech_empa/plugins/bader.py
@@ -1,6 +1,5 @@
 from aiida import common, engine, orm
 
-
 DEFAULT_CHARGE_DENSITY_FILENAME = "aiida-ELECTRON_DENSITY-1_0.cube"
 DEFAULT_RETRIEVE_LIST = ["ACF.dat", "AVF.dat", "BCF.dat"]
 

--- a/aiida_nanotech_empa/plugins/sparse_overlap.py
+++ b/aiida_nanotech_empa/plugins/sparse_overlap.py
@@ -1,0 +1,79 @@
+from aiida import common, engine, orm
+
+
+DEFAULT_MATRIX_FILENAME = "aiida-overlap_matrix.out-1_0.Log"
+DEFAULT_OUTPUT_FILENAME = "sparse_overlap.npz"
+
+
+class SparseOverlapCalculation(engine.CalcJob):
+    @classmethod
+    def define(cls, spec):
+        super().define(spec)
+        spec.input(
+            "parent_calc_folder",
+            valid_type=orm.RemoteData,
+            help="CP2K folder with the AO overlap matrix log file.",
+        )
+        spec.input(
+            "threshold",
+            valid_type=orm.Float,
+            default=lambda: orm.Float(1.0e-10),
+            required=False,
+            help="Store matrix elements whose absolute value is larger than this threshold.",
+        )
+        spec.input(
+            "matrix_filename",
+            valid_type=orm.Str,
+            default=lambda: orm.Str(DEFAULT_MATRIX_FILENAME),
+            required=False,
+        )
+        spec.input(
+            "output_filename",
+            valid_type=orm.Str,
+            default=lambda: orm.Str(DEFAULT_OUTPUT_FILENAME),
+            required=False,
+        )
+        spec.input(
+            "settings",
+            valid_type=orm.Dict,
+            default=lambda: orm.Dict(dict={}),
+            required=False,
+        )
+        spec.input("metadata.options.withmpi", valid_type=bool, default=False)
+
+    def prepare_for_submission(self, folder):
+        settings = self.inputs.settings.get_dict() if "settings" in self.inputs else {}
+
+        output_filename = self.inputs.output_filename.value
+        codeinfo = common.CodeInfo()
+        codeinfo.code_uuid = self.inputs.code.uuid
+        codeinfo.cmdline_params = [
+            "parent_calc_folder/" + self.inputs.matrix_filename.value,
+            output_filename,
+            "--threshold",
+            str(self.inputs.threshold.value),
+        ]
+
+        calcinfo = common.CalcInfo()
+        calcinfo.uuid = self.uuid
+        calcinfo.codes_info = [codeinfo]
+        calcinfo.remote_symlink_list = []
+        calcinfo.remote_copy_list = []
+        calcinfo.local_copy_list = []
+        calcinfo.retrieve_list = settings.pop("additional_retrieve_list", [output_filename])
+
+        comp_uuid = self.inputs.parent_calc_folder.computer.uuid
+        remote_path = self.inputs.parent_calc_folder.get_remote_path()
+        copy_info = (comp_uuid, remote_path, "parent_calc_folder/")
+        if self.inputs.code.computer.uuid == comp_uuid:
+            calcinfo.remote_symlink_list.append(copy_info)
+        else:
+            calcinfo.remote_copy_list.append(copy_info)
+
+        if settings:
+            raise common.InputValidationError(
+                "The following keys have been found in settings but were not understood: "
+                + ",".join(settings.keys())
+            )
+
+        return calcinfo

--- a/aiida_nanotech_empa/plugins/sparse_overlap.py
+++ b/aiida_nanotech_empa/plugins/sparse_overlap.py
@@ -1,6 +1,5 @@
 from aiida import common, engine, orm
 
-
 DEFAULT_MATRIX_FILENAME = "aiida-overlap_matrix.out-1_0.Log"
 DEFAULT_OUTPUT_FILENAME = "sparse_overlap.npz"
 
@@ -60,7 +59,9 @@ class SparseOverlapCalculation(engine.CalcJob):
         calcinfo.remote_symlink_list = []
         calcinfo.remote_copy_list = []
         calcinfo.local_copy_list = []
-        calcinfo.retrieve_list = settings.pop("additional_retrieve_list", [output_filename])
+        calcinfo.retrieve_list = settings.pop(
+            "additional_retrieve_list", [output_filename]
+        )
 
         comp_uuid = self.inputs.parent_calc_folder.computer.uuid
         remote_path = self.inputs.parent_calc_folder.get_remote_path()

--- a/aiida_nanotech_empa/plugins/unfolding.py
+++ b/aiida_nanotech_empa/plugins/unfolding.py
@@ -1,0 +1,86 @@
+from aiida import common, engine, orm
+
+
+DEFAULT_WFN_FILENAME = "aiida-RESTART.wfn"
+DEFAULT_XYZ_FILENAME = "aiida.coords.xyz"
+DEFAULT_CP2K_INPUT_FILENAME = "aiida.inp"
+DEFAULT_MATRIX_FILENAME = "aiida-overlap_matrix.out-1_0.Log"
+DEFAULT_OUTPUT_FILENAME = "unfolding_bands.npz"
+
+
+class Cp2kUnfoldingCalculation(engine.CalcJob):
+    @classmethod
+    def define(cls, spec):
+        super().define(spec)
+        spec.input(
+            "parent_calc_folder",
+            valid_type=orm.RemoteData,
+            help="CP2K diagonalization folder containing the WFN, coordinates, and CP2K input.",
+        )
+        spec.input("primitive_vectors", valid_type=orm.Str)
+        spec.input("path", valid_type=orm.Str, default=lambda: orm.Str("G-K-M-G"), required=False)
+        spec.input("lattice_type", valid_type=orm.Str, default=lambda: orm.Str("auto"), required=False)
+        spec.input("emin", valid_type=orm.Float, required=False)
+        spec.input("emax", valid_type=orm.Float, required=False)
+        spec.input("wfn_filename", valid_type=orm.Str, default=lambda: orm.Str(DEFAULT_WFN_FILENAME), required=False)
+        spec.input("xyz_filename", valid_type=orm.Str, default=lambda: orm.Str(DEFAULT_XYZ_FILENAME), required=False)
+        spec.input("cp2k_input_filename", valid_type=orm.Str, default=lambda: orm.Str(DEFAULT_CP2K_INPUT_FILENAME), required=False)
+        spec.input("matrix_filename", valid_type=orm.Str, default=lambda: orm.Str(DEFAULT_MATRIX_FILENAME), required=False)
+        spec.input("overlap_threshold", valid_type=orm.Float, default=lambda: orm.Float(1.0e-10), required=False)
+        spec.input("output_filename", valid_type=orm.Str, default=lambda: orm.Str(DEFAULT_OUTPUT_FILENAME), required=False)
+        spec.input("settings", valid_type=orm.Dict, default=lambda: orm.Dict(dict={}), required=False)
+        spec.input("metadata.options.withmpi", valid_type=bool, default=False)
+
+    def prepare_for_submission(self, folder):
+        settings = self.inputs.settings.get_dict() if "settings" in self.inputs else {}
+        output_filename = self.inputs.output_filename.value
+
+        codeinfo = common.CodeInfo()
+        codeinfo.code_uuid = self.inputs.code.uuid
+        codeinfo.cmdline_params = [
+            "parent_calc_folder/" + self.inputs.wfn_filename.value,
+            "parent_calc_folder/" + self.inputs.matrix_filename.value,
+            output_filename,
+            "--xyz",
+            "parent_calc_folder/" + self.inputs.xyz_filename.value,
+            "--cp2k-input",
+            "parent_calc_folder/" + self.inputs.cp2k_input_filename.value,
+            "--primitive-vectors",
+            self.inputs.primitive_vectors.value,
+            "--path",
+            self.inputs.path.value,
+            "--lattice-type",
+            self.inputs.lattice_type.value,
+            "--overlap-format",
+            "log",
+            "--overlap-threshold",
+            str(self.inputs.overlap_threshold.value),
+        ]
+        if "emin" in self.inputs:
+            codeinfo.cmdline_params.extend(["--emin", str(self.inputs.emin.value)])
+        if "emax" in self.inputs:
+            codeinfo.cmdline_params.extend(["--emax", str(self.inputs.emax.value)])
+
+        calcinfo = common.CalcInfo()
+        calcinfo.uuid = self.uuid
+        calcinfo.codes_info = [codeinfo]
+        calcinfo.remote_symlink_list = []
+        calcinfo.remote_copy_list = []
+        calcinfo.local_copy_list = []
+        calcinfo.retrieve_list = settings.pop("additional_retrieve_list", [output_filename])
+
+        comp_uuid = self.inputs.parent_calc_folder.computer.uuid
+        remote_path = self.inputs.parent_calc_folder.get_remote_path()
+        copy_info = (comp_uuid, remote_path, "parent_calc_folder/")
+        if self.inputs.code.computer.uuid == comp_uuid:
+            calcinfo.remote_symlink_list.append(copy_info)
+        else:
+            calcinfo.remote_copy_list.append(copy_info)
+
+        if settings:
+            raise common.InputValidationError(
+                "The following keys have been found in settings but were not understood: "
+                + ",".join(settings.keys())
+            )
+
+        return calcinfo

--- a/aiida_nanotech_empa/plugins/unfolding.py
+++ b/aiida_nanotech_empa/plugins/unfolding.py
@@ -6,6 +6,7 @@ DEFAULT_XYZ_FILENAME = "aiida.coords.xyz"
 DEFAULT_CP2K_INPUT_FILENAME = "aiida.inp"
 DEFAULT_MATRIX_FILENAME = "aiida-overlap_matrix.out-1_0.Log"
 DEFAULT_OUTPUT_FILENAME = "unfolding_bands.npz"
+DEFAULT_PDOS_PROJECTION_FILENAME = "unfolding_projections.npz"
 
 
 class Cp2kUnfoldingCalculation(engine.CalcJob):
@@ -28,6 +29,24 @@ class Cp2kUnfoldingCalculation(engine.CalcJob):
         spec.input("matrix_filename", valid_type=orm.Str, default=lambda: orm.Str(DEFAULT_MATRIX_FILENAME), required=False)
         spec.input("overlap_threshold", valid_type=orm.Float, default=lambda: orm.Float(1.0e-10), required=False)
         spec.input("output_filename", valid_type=orm.Str, default=lambda: orm.Str(DEFAULT_OUTPUT_FILENAME), required=False)
+        spec.input(
+            "parse_pdos_projections",
+            valid_type=orm.Bool,
+            default=lambda: orm.Bool(False),
+            required=False,
+        )
+        spec.input(
+            "pdos_projection_filename",
+            valid_type=orm.Str,
+            default=lambda: orm.Str(DEFAULT_PDOS_PROJECTION_FILENAME),
+            required=False,
+        )
+        spec.input(
+            "pdos_threshold",
+            valid_type=orm.Float,
+            default=lambda: orm.Float(1.0e-4),
+            required=False,
+        )
         spec.input("settings", valid_type=orm.Dict, default=lambda: orm.Dict(dict={}), required=False)
         spec.input("metadata.options.withmpi", valid_type=bool, default=False)
 
@@ -60,6 +79,17 @@ class Cp2kUnfoldingCalculation(engine.CalcJob):
             codeinfo.cmdline_params.extend(["--emin", str(self.inputs.emin.value)])
         if "emax" in self.inputs:
             codeinfo.cmdline_params.extend(["--emax", str(self.inputs.emax.value)])
+        if self.inputs.parse_pdos_projections.value:
+            codeinfo.cmdline_params.extend(
+                [
+                    "--pdos-glob",
+                    "parent_calc_folder/aiida-*list*-1.pdos",
+                    "--pdos-output",
+                    self.inputs.pdos_projection_filename.value,
+                    "--pdos-threshold",
+                    str(self.inputs.pdos_threshold.value),
+                ]
+            )
 
         calcinfo = common.CalcInfo()
         calcinfo.uuid = self.uuid
@@ -67,7 +97,10 @@ class Cp2kUnfoldingCalculation(engine.CalcJob):
         calcinfo.remote_symlink_list = []
         calcinfo.remote_copy_list = []
         calcinfo.local_copy_list = []
-        calcinfo.retrieve_list = settings.pop("additional_retrieve_list", [output_filename])
+        default_retrieve_list = [output_filename]
+        if self.inputs.parse_pdos_projections.value:
+            default_retrieve_list.append(self.inputs.pdos_projection_filename.value)
+        calcinfo.retrieve_list = settings.pop("additional_retrieve_list", default_retrieve_list)
 
         comp_uuid = self.inputs.parent_calc_folder.computer.uuid
         remote_path = self.inputs.parent_calc_folder.get_remote_path()

--- a/aiida_nanotech_empa/plugins/unfolding.py
+++ b/aiida_nanotech_empa/plugins/unfolding.py
@@ -1,6 +1,5 @@
 from aiida import common, engine, orm
 
-
 DEFAULT_WFN_FILENAME = "aiida-RESTART.wfn"
 DEFAULT_XYZ_FILENAME = "aiida.coords.xyz"
 DEFAULT_CP2K_INPUT_FILENAME = "aiida.inp"
@@ -19,16 +18,56 @@ class Cp2kUnfoldingCalculation(engine.CalcJob):
             help="CP2K diagonalization folder containing the WFN, coordinates, and CP2K input.",
         )
         spec.input("primitive_vectors", valid_type=orm.Str)
-        spec.input("path", valid_type=orm.Str, default=lambda: orm.Str("G-K-M-G"), required=False)
-        spec.input("lattice_type", valid_type=orm.Str, default=lambda: orm.Str("auto"), required=False)
+        spec.input(
+            "path",
+            valid_type=orm.Str,
+            default=lambda: orm.Str("G-K-M-G"),
+            required=False,
+        )
+        spec.input(
+            "lattice_type",
+            valid_type=orm.Str,
+            default=lambda: orm.Str("auto"),
+            required=False,
+        )
         spec.input("emin", valid_type=orm.Float, required=False)
         spec.input("emax", valid_type=orm.Float, required=False)
-        spec.input("wfn_filename", valid_type=orm.Str, default=lambda: orm.Str(DEFAULT_WFN_FILENAME), required=False)
-        spec.input("xyz_filename", valid_type=orm.Str, default=lambda: orm.Str(DEFAULT_XYZ_FILENAME), required=False)
-        spec.input("cp2k_input_filename", valid_type=orm.Str, default=lambda: orm.Str(DEFAULT_CP2K_INPUT_FILENAME), required=False)
-        spec.input("matrix_filename", valid_type=orm.Str, default=lambda: orm.Str(DEFAULT_MATRIX_FILENAME), required=False)
-        spec.input("overlap_threshold", valid_type=orm.Float, default=lambda: orm.Float(1.0e-10), required=False)
-        spec.input("output_filename", valid_type=orm.Str, default=lambda: orm.Str(DEFAULT_OUTPUT_FILENAME), required=False)
+        spec.input(
+            "wfn_filename",
+            valid_type=orm.Str,
+            default=lambda: orm.Str(DEFAULT_WFN_FILENAME),
+            required=False,
+        )
+        spec.input(
+            "xyz_filename",
+            valid_type=orm.Str,
+            default=lambda: orm.Str(DEFAULT_XYZ_FILENAME),
+            required=False,
+        )
+        spec.input(
+            "cp2k_input_filename",
+            valid_type=orm.Str,
+            default=lambda: orm.Str(DEFAULT_CP2K_INPUT_FILENAME),
+            required=False,
+        )
+        spec.input(
+            "matrix_filename",
+            valid_type=orm.Str,
+            default=lambda: orm.Str(DEFAULT_MATRIX_FILENAME),
+            required=False,
+        )
+        spec.input(
+            "overlap_threshold",
+            valid_type=orm.Float,
+            default=lambda: orm.Float(1.0e-10),
+            required=False,
+        )
+        spec.input(
+            "output_filename",
+            valid_type=orm.Str,
+            default=lambda: orm.Str(DEFAULT_OUTPUT_FILENAME),
+            required=False,
+        )
         spec.input(
             "parse_pdos_projections",
             valid_type=orm.Bool,
@@ -47,7 +86,12 @@ class Cp2kUnfoldingCalculation(engine.CalcJob):
             default=lambda: orm.Float(1.0e-4),
             required=False,
         )
-        spec.input("settings", valid_type=orm.Dict, default=lambda: orm.Dict(dict={}), required=False)
+        spec.input(
+            "settings",
+            valid_type=orm.Dict,
+            default=lambda: orm.Dict(dict={}),
+            required=False,
+        )
         spec.input("metadata.options.withmpi", valid_type=bool, default=False)
 
     def prepare_for_submission(self, folder):
@@ -100,7 +144,9 @@ class Cp2kUnfoldingCalculation(engine.CalcJob):
         default_retrieve_list = [output_filename]
         if self.inputs.parse_pdos_projections.value:
             default_retrieve_list.append(self.inputs.pdos_projection_filename.value)
-        calcinfo.retrieve_list = settings.pop("additional_retrieve_list", default_retrieve_list)
+        calcinfo.retrieve_list = settings.pop(
+            "additional_retrieve_list", default_retrieve_list
+        )
 
         comp_uuid = self.inputs.parent_calc_folder.computer.uuid
         remote_path = self.inputs.parent_calc_folder.get_remote_path()

--- a/aiida_nanotech_empa/utils/split_structure.py
+++ b/aiida_nanotech_empa/utils/split_structure.py
@@ -9,7 +9,7 @@ def split_structure(structure, fixed_atoms, magnetization_per_site, fragments):
 
     allfixed = [0 for i in ase_geo]
     mps = []
-    fixed = ""
+    fixed = []
     if "all" not in fragments:
         yield {
             "label": "all",
@@ -50,6 +50,8 @@ def split_structure(structure, fixed_atoms, magnetization_per_site, fragments):
         yield {
             "label": fragment_label,
             "structure": StructureData(ase=ase_geo[fragment]),
-            "fixed_atoms": orm.List(list=np.nonzero(fixed)[0].tolist()),
+            "fixed_atoms": orm.List(
+                list=[index for index, is_fixed in enumerate(fixed) if is_fixed]
+            ),
             "magnetization_per_site": orm.List(list=mps),
         }

--- a/aiida_nanotech_empa/workflows/cp2k/__init__.py
+++ b/aiida_nanotech_empa/workflows/cp2k/__init__.py
@@ -12,6 +12,7 @@ from .pdos_workchain import Cp2kPdosWorkChain
 from .phonons_workchain import Cp2kPhononsWorkChain
 from .reftraj_md_workchain import Cp2kRefTrajWorkChain
 from .replica_workchain import Cp2kReplicaWorkChain
+from .scf_workchain import Cp2kScfWorkChain
 from .stm_workchain import Cp2kStmWorkChain
 
 __all__ = (
@@ -26,6 +27,7 @@ __all__ = (
     "Cp2kAfmWorkChain",
     "Cp2kHrstmWorkChain",
     "Cp2kDiagWorkChain",
+    "Cp2kScfWorkChain",
     "Cp2kReplicaWorkChain",
     "Cp2kNebWorkChain",
     "Cp2kPhononsWorkChain",

--- a/aiida_nanotech_empa/workflows/cp2k/adsorbed_gw_ic_workchain.py
+++ b/aiida_nanotech_empa/workflows/cp2k/adsorbed_gw_ic_workchain.py
@@ -2,8 +2,8 @@ import numpy as np
 from aiida import engine, orm
 
 from .geo_opt_workchain import Cp2kGeoOptWorkChain
-from .molecule_opt_gw_workchain import geo_opt_dft_params
 from .molecule_gw_workchain import Cp2kMoleculeGwWorkChain
+from .molecule_opt_gw_workchain import geo_opt_dft_params
 
 IC_PLANE_HEIGHTS = {
     "Au(111)": 1.42,  # Kharche J. Phys. Chem. Lett. 7, 1526–1533 (2016).

--- a/aiida_nanotech_empa/workflows/cp2k/cp2k_utils.py
+++ b/aiida_nanotech_empa/workflows/cp2k/cp2k_utils.py
@@ -560,7 +560,7 @@ def string_range_to_list(strng, shift=-1):
             return [], False
 
         if ".." in item:
-            start, end = [int(value) for value in item.split("..")]
+            start, end = (int(value) for value in item.split(".."))
             if start > end:
                 return [], False
             indexes.extend(i + shift for i in range(start, end + 1))
@@ -705,9 +705,7 @@ def get_ids(details, label=None):
             pos = lab + 2
             if details[lab + 1].lower() == "atoms":
                 ids0, pos = _collect_atom_index_tokens(details, pos)
-                _require_atom_index_end(
-                    details, pos, {"point", "plane", "axis", "end"}
-                )
+                _require_atom_index_end(details, pos, {"point", "plane", "axis", "end"})
                 ids0 = _atom_indexes_to_cp2k_list(ids0)
             else:
                 while pos < len(details) and is_number(details[pos]):

--- a/aiida_nanotech_empa/workflows/cp2k/diag_workchain.py
+++ b/aiida_nanotech_empa/workflows/cp2k/diag_workchain.py
@@ -13,9 +13,7 @@ Cp2kBaseWorkChain = plugins.WorkflowFactory("cp2k.base")
 
 class Cp2kDiagWorkChain(engine.WorkChain):
     @classmethod
-    def define(cls, spec):
-        super().define(spec)
-
+    def define_common_inputs(cls, spec):
         spec.input("cp2k_code", valid_type=orm.Code)
         spec.input("structure", valid_type=orm.StructureData)
         spec.input("parent_calc_folder", valid_type=orm.RemoteData, required=False)
@@ -74,13 +72,9 @@ class Cp2kDiagWorkChain(engine.WorkChain):
             required=False,
             help="Pause cp2k.base for inspection when restart max_iterations is reached.",
         )
-        spec.outline(
-            cls.setup,
-            cls.run_ot_scf,
-            cls.run_diag_scf,
-            cls.finalize,
-        )
 
+    @classmethod
+    def define_common_outputs(cls, spec):
         spec.outputs.dynamic = True
 
         spec.exit_code(
@@ -88,6 +82,18 @@ class Cp2kDiagWorkChain(engine.WorkChain):
             "ERROR_TERMINATION",
             message="One or more steps of the work chain failed.",
         )
+
+    @classmethod
+    def define(cls, spec):
+        super().define(spec)
+        cls.define_common_inputs(spec)
+        spec.outline(
+            cls.setup,
+            cls.run_ot_scf,
+            cls.run_diag_scf,
+            cls.finalize,
+        )
+        cls.define_common_outputs(spec)
 
     def set_restart_policy(self, builder):
         builder.max_iterations = self.inputs.max_iterations
@@ -110,6 +116,10 @@ class Cp2kDiagWorkChain(engine.WorkChain):
         self.ctx.n_atoms = len(structure.sites)
 
         self.ctx.dft_params = self.inputs.dft_params.get_dict()
+        self.ctx.dft_params.setdefault("periodic", "XYZ")
+        self.ctx.dft_params.setdefault("uks", False)
+        self.ctx.dft_params.setdefault("elpa_switch", False)
+        self.ctx.dft_params.setdefault("sc_diag", False)
 
         # Resources.
         self.ctx.options = self.inputs.options.get_dict()
@@ -279,6 +289,8 @@ class Cp2kDiagWorkChain(engine.WorkChain):
             )
             input_dict["FORCE_EVAL"]["DFT"]["PRINT"]["MO_CUBES"]["STRIDE"] = "2 2 2"
 
+        self.update_diag_input_dict(input_dict)
+
         # Setup walltime.
         input_dict["GLOBAL"]["WALLTIME"] = max(
             600, self.ctx.options["max_wallclock_seconds"] - 600
@@ -319,3 +331,6 @@ class Cp2kDiagWorkChain(engine.WorkChain):
         self.out("remote_folder", self.ctx.diag_scf.outputs.remote_folder)
         self.out("retrieved", self.ctx.diag_scf.outputs.retrieved)
         self.report("Work chain is finished")
+
+    def update_diag_input_dict(self, input_dict):
+        """Hook for derived workchains to add diagonalization-only CP2K input."""

--- a/aiida_nanotech_empa/workflows/cp2k/diag_workchain.py
+++ b/aiida_nanotech_empa/workflows/cp2k/diag_workchain.py
@@ -212,12 +212,17 @@ class Cp2kDiagWorkChain(engine.WorkChain):
         # Parser.
         builder.cp2k.metadata.options.parser_name = "cp2k_advanced_parser"
 
+        self.update_ot_input_dict(input_dict)
+
         # CP2K input dictionary.
         builder.cp2k.parameters = orm.Dict(input_dict)
         self.ctx.input_dict = copy.deepcopy(input_dict)
 
         future = self.submit(builder)
         self.to_context(ot_scf=future)
+
+    def update_ot_input_dict(self, input_dict):
+        pass
 
     def run_diag_scf(self):
         self.report("Running CP2K diagonalization SCF")

--- a/aiida_nanotech_empa/workflows/cp2k/scf_workchain.py
+++ b/aiida_nanotech_empa/workflows/cp2k/scf_workchain.py
@@ -174,9 +174,9 @@ class Cp2kScfWorkChain(Cp2kDiagWorkChain):
         if not self.should_run_bader():
             return
 
-        input_dict["FORCE_EVAL"]["DFT"]["MGRID"]["CUTOFF"] = (
-            self.inputs.bader_cutoff.value
-        )
+        input_dict["FORCE_EVAL"]["DFT"]["MGRID"][
+            "CUTOFF"
+        ] = self.inputs.bader_cutoff.value
         print_section = input_dict["FORCE_EVAL"]["DFT"].setdefault("PRINT", {})
         charge_density = print_section.setdefault("E_DENSITY_CUBE", {})
         charge_density["STRIDE"] = "1 1 1"
@@ -340,7 +340,9 @@ class Cp2kScfWorkChain(Cp2kDiagWorkChain):
                     self.ctx.unfolding.outputs.retrieved.base.repository.list_object_names()
                 )
                 if output_filename not in retrieved_names:
-                    self.report(f"CP2K band unfolding did not retrieve {output_filename}")
+                    self.report(
+                        f"CP2K band unfolding did not retrieve {output_filename}"
+                    )
                     return self.exit_codes.ERROR_MISSING_UNFOLDING_OUTPUT
                 if self.ctx.unfolding.inputs.parse_pdos_projections.value:
                     projection_filename = (

--- a/aiida_nanotech_empa/workflows/cp2k/scf_workchain.py
+++ b/aiida_nanotech_empa/workflows/cp2k/scf_workchain.py
@@ -5,6 +5,7 @@ from .diag_workchain import Cp2kDiagWorkChain
 
 BaderCalculation = plugins.CalculationFactory("nanotech_empa.bader")
 SparseOverlapCalculation = plugins.CalculationFactory("nanotech_empa.sparse_overlap")
+Cp2kUnfoldingCalculation = plugins.CalculationFactory("nanotech_empa.cp2k_unfolding")
 
 
 class Cp2kScfWorkChain(Cp2kDiagWorkChain):
@@ -65,6 +66,39 @@ class Cp2kScfWorkChain(Cp2kDiagWorkChain):
             required=False,
             help="Plane-wave cutoff used for the OT charge-density cube for Bader analysis.",
         )
+        spec.input(
+            "compute_unfolding",
+            valid_type=orm.Bool,
+            default=lambda: orm.Bool(False),
+            required=False,
+            help="Post-process WFN and sparse AO overlap into unfolded band weights.",
+        )
+        spec.input(
+            "unfolding_code",
+            valid_type=orm.Code,
+            required=False,
+            help="Python code configured for the nanotech_empa.cp2k_unfolding plugin.",
+        )
+        spec.input(
+            "unfolding_primitive_vectors",
+            valid_type=orm.Str,
+            required=False,
+            help="Approximate primitive vectors as rows, separated by semicolons or newlines.",
+        )
+        spec.input(
+            "unfolding_path",
+            valid_type=orm.Str,
+            default=lambda: orm.Str("G-K-M-G"),
+            required=False,
+            help="High-symmetry path labels, e.g. G-K-M-G.",
+        )
+        spec.input(
+            "unfolding_lattice_type",
+            valid_type=orm.Str,
+            default=lambda: orm.Str("auto"),
+            required=False,
+            help="1d, square, rectangular, hexagonal, oblique, or auto.",
+        )
         spec.outline(
             cls.setup,
             cls.run_ot_scf,
@@ -72,6 +106,9 @@ class Cp2kScfWorkChain(Cp2kDiagWorkChain):
                 cls.run_diag_scf,
                 engine.if_(cls.should_run_sparse_overlap)(
                     cls.run_sparse_overlap,
+                ),
+                engine.if_(cls.should_run_unfolding)(
+                    cls.run_unfolding,
                 ),
             ),
             engine.if_(cls.should_run_bader)(
@@ -89,6 +126,16 @@ class Cp2kScfWorkChain(Cp2kDiagWorkChain):
             "ERROR_MISSING_BADER_CODE",
             message="A Bader code is required to compute Bader charges.",
         )
+        spec.exit_code(
+            393,
+            "ERROR_MISSING_UNFOLDING_CODE",
+            message="An unfolding code is required to compute band unfolding.",
+        )
+        spec.exit_code(
+            394,
+            "ERROR_MISSING_UNFOLDING_PRIMITIVE_VECTORS",
+            message="Primitive vectors are required to compute band unfolding.",
+        )
 
     def should_run_diag_scf(self):
         if self.should_run_bader():
@@ -98,6 +145,7 @@ class Cp2kScfWorkChain(Cp2kDiagWorkChain):
         return (
             self.inputs.write_overlap_matrix.value
             or self.inputs.retrieve_sparse_overlap.value
+            or self.inputs.compute_unfolding.value
             or dft_params.get("added_mos", 0) > 0
         )
 
@@ -106,6 +154,9 @@ class Cp2kScfWorkChain(Cp2kDiagWorkChain):
 
     def should_run_sparse_overlap(self):
         return self.inputs.retrieve_sparse_overlap.value
+
+    def should_run_unfolding(self):
+        return self.inputs.compute_unfolding.value
 
     def update_ot_input_dict(self, input_dict):
         if not self.should_run_bader():
@@ -124,6 +175,7 @@ class Cp2kScfWorkChain(Cp2kDiagWorkChain):
         if not (
             self.inputs.write_overlap_matrix.value
             or self.inputs.retrieve_sparse_overlap.value
+            or self.inputs.compute_unfolding.value
         ):
             return
 
@@ -161,6 +213,36 @@ class Cp2kScfWorkChain(Cp2kDiagWorkChain):
             },
         }
         return engine.ToContext(sparse_overlap=self.submit(builder))
+
+    def run_unfolding(self):
+        if "unfolding_code" not in self.inputs:
+            return self.exit_codes.ERROR_MISSING_UNFOLDING_CODE
+        if "unfolding_primitive_vectors" not in self.inputs:
+            return self.exit_codes.ERROR_MISSING_UNFOLDING_PRIMITIVE_VECTORS
+
+        self.report("Running CP2K band unfolding post-processing")
+        builder = Cp2kUnfoldingCalculation.get_builder()
+        builder.code = self.inputs.unfolding_code
+        builder.parent_calc_folder = self.ctx.diag_scf.outputs.remote_folder
+        builder.primitive_vectors = self.inputs.unfolding_primitive_vectors
+        builder.path = self.inputs.unfolding_path
+        builder.lattice_type = self.inputs.unfolding_lattice_type
+        builder.overlap_threshold = self.inputs.overlap_threshold
+        builder.metadata = {
+            "label": "cp2k_unfolding",
+            "options": {
+                "resources": {
+                    "num_machines": 1,
+                    "num_mpiprocs_per_machine": 1,
+                    "num_cores_per_mpiproc": 1,
+                },
+                "max_wallclock_seconds": min(
+                    7200, self.ctx.options["max_wallclock_seconds"]
+                ),
+                "withmpi": False,
+            },
+        }
+        return engine.ToContext(unfolding=self.submit(builder))
 
     def run_bader(self):
         if "bader_code" not in self.inputs:
@@ -219,10 +301,17 @@ class Cp2kScfWorkChain(Cp2kDiagWorkChain):
                 if not common_utils.check_if_calc_ok(self, self.ctx.sparse_overlap):
                     self.report("sparse overlap post-processing failed")
                     return self.exit_codes.ERROR_TERMINATION
-                self.out(
-                    "sparse_overlap_retrieved",
-                    self.ctx.sparse_overlap.outputs.retrieved,
-                )
+                if self.inputs.retrieve_sparse_overlap.value:
+                    self.out(
+                        "sparse_overlap_retrieved",
+                        self.ctx.sparse_overlap.outputs.retrieved,
+                    )
+
+            if self.should_run_unfolding():
+                if not common_utils.check_if_calc_ok(self, self.ctx.unfolding):
+                    self.report("CP2K band unfolding post-processing failed")
+                    return self.exit_codes.ERROR_TERMINATION
+                self.out("unfolding_retrieved", self.ctx.unfolding.outputs.retrieved)
 
             self.out("output_parameters", self.ctx.diag_scf.outputs.output_parameters)
             self.out("remote_folder", self.ctx.diag_scf.outputs.remote_folder)

--- a/aiida_nanotech_empa/workflows/cp2k/scf_workchain.py
+++ b/aiida_nanotech_empa/workflows/cp2k/scf_workchain.py
@@ -3,6 +3,7 @@ from aiida import engine, orm, plugins
 from ...utils import common_utils
 from .diag_workchain import Cp2kDiagWorkChain
 
+BaderCalculation = plugins.CalculationFactory("nanotech_empa.bader")
 SparseOverlapCalculation = plugins.CalculationFactory("nanotech_empa.sparse_overlap")
 
 
@@ -44,6 +45,26 @@ class Cp2kScfWorkChain(Cp2kDiagWorkChain):
             required=False,
             help="Absolute-value threshold for retrieved sparse overlap entries.",
         )
+        spec.input(
+            "compute_bader_charges",
+            valid_type=orm.Bool,
+            default=lambda: orm.Bool(False),
+            required=False,
+            help="Run Bader charge analysis on the OT charge-density cube.",
+        )
+        spec.input(
+            "bader_code",
+            valid_type=orm.Code,
+            required=False,
+            help="Bader executable configured for the nanotech_empa.bader plugin.",
+        )
+        spec.input(
+            "bader_cutoff",
+            valid_type=orm.Float,
+            default=lambda: orm.Float(1200.0),
+            required=False,
+            help="Plane-wave cutoff used for the OT charge-density cube for Bader analysis.",
+        )
         spec.outline(
             cls.setup,
             cls.run_ot_scf,
@@ -53,6 +74,9 @@ class Cp2kScfWorkChain(Cp2kDiagWorkChain):
                     cls.run_sparse_overlap,
                 ),
             ),
+            engine.if_(cls.should_run_bader)(
+                cls.run_bader,
+            ),
             cls.finalize,
         )
         spec.exit_code(
@@ -60,8 +84,16 @@ class Cp2kScfWorkChain(Cp2kDiagWorkChain):
             "ERROR_MISSING_SPARSE_OVERLAP_CODE",
             message="A sparse overlap code is required to retrieve sparse overlap entries.",
         )
+        spec.exit_code(
+            392,
+            "ERROR_MISSING_BADER_CODE",
+            message="A Bader code is required to compute Bader charges.",
+        )
 
     def should_run_diag_scf(self):
+        if self.should_run_bader():
+            return False
+
         dft_params = self.inputs.dft_params.get_dict()
         return (
             self.inputs.write_overlap_matrix.value
@@ -69,8 +101,24 @@ class Cp2kScfWorkChain(Cp2kDiagWorkChain):
             or dft_params.get("added_mos", 0) > 0
         )
 
+    def should_run_bader(self):
+        return self.inputs.compute_bader_charges.value
+
     def should_run_sparse_overlap(self):
         return self.inputs.retrieve_sparse_overlap.value
+
+    def update_ot_input_dict(self, input_dict):
+        if not self.should_run_bader():
+            return
+
+        input_dict["FORCE_EVAL"]["DFT"]["MGRID"]["CUTOFF"] = (
+            self.inputs.bader_cutoff.value
+        )
+        print_section = input_dict["FORCE_EVAL"]["DFT"].setdefault("PRINT", {})
+        charge_density = print_section.setdefault("E_DENSITY_CUBE", {})
+        charge_density["STRIDE"] = "1 1 1"
+        charge_density.setdefault("EACH", {"QS_SCF": "0", "GEO_OPT": "0"})
+        charge_density.setdefault("ADD_LAST", "NUMERIC")
 
     def update_diag_input_dict(self, input_dict):
         if not (
@@ -114,7 +162,52 @@ class Cp2kScfWorkChain(Cp2kDiagWorkChain):
         }
         return engine.ToContext(sparse_overlap=self.submit(builder))
 
+    def run_bader(self):
+        if "bader_code" not in self.inputs:
+            return self.exit_codes.ERROR_MISSING_BADER_CODE
+
+        if not common_utils.check_if_calc_ok(self, self.ctx.ot_scf):
+            self.report("OT SCF failed")
+            return self.exit_codes.ERROR_TERMINATION
+
+        self.report("Running Bader charge analysis")
+        builder = BaderCalculation.get_builder()
+        builder.code = self.inputs.bader_code
+        builder.parent_calc_folder = self.ctx.ot_scf.outputs.remote_folder
+        builder.charge_density_filename = orm.Str("aiida-ELECTRON_DENSITY-1_0.cube")
+        builder.metadata = {
+            "label": "bader",
+            "options": {
+                "resources": {
+                    "num_machines": 1,
+                    "num_mpiprocs_per_machine": 1,
+                    "num_cores_per_mpiproc": 1,
+                },
+                "max_wallclock_seconds": min(
+                    3600, self.ctx.options["max_wallclock_seconds"]
+                ),
+                "withmpi": False,
+            },
+        }
+        return engine.ToContext(bader=self.submit(builder))
+
     def finalize(self):
+        if self.should_run_bader():
+            if not common_utils.check_if_calc_ok(self, self.ctx.ot_scf):
+                self.report("OT SCF failed")
+                return self.exit_codes.ERROR_TERMINATION
+
+            if not common_utils.check_if_calc_ok(self, self.ctx.bader):
+                self.report("Bader charge analysis failed")
+                return self.exit_codes.ERROR_TERMINATION
+
+            self.out("output_parameters", self.ctx.ot_scf.outputs.output_parameters)
+            self.out("remote_folder", self.ctx.ot_scf.outputs.remote_folder)
+            self.out("retrieved", self.ctx.ot_scf.outputs.retrieved)
+            self.out("bader_retrieved", self.ctx.bader.outputs.retrieved)
+            self.report("Work chain is finished")
+            return None
+
         if self.should_run_diag_scf():
             if not common_utils.check_if_calc_ok(self, self.ctx.diag_scf):
                 self.report("diagonalization scf failed")

--- a/aiida_nanotech_empa/workflows/cp2k/scf_workchain.py
+++ b/aiida_nanotech_empa/workflows/cp2k/scf_workchain.py
@@ -99,6 +99,13 @@ class Cp2kScfWorkChain(Cp2kDiagWorkChain):
             required=False,
             help="1d, square, rectangular, hexagonal, oblique, or auto.",
         )
+        spec.input(
+            "unfolding_pdos_threshold",
+            valid_type=orm.Float,
+            default=lambda: orm.Float(1.0e-4),
+            required=False,
+            help="Projection threshold for compact atom-resolved PDOS data attached to unfolding.",
+        )
         spec.outline(
             cls.setup,
             cls.run_ot_scf,
@@ -192,6 +199,16 @@ class Cp2kScfWorkChain(Cp2kDiagWorkChain):
             "NDIGITS": self.inputs.overlap_ndigits.value,
         }
 
+        if self.inputs.compute_unfolding.value:
+            added_mos = int(self.ctx.dft_params.get("added_mos", 0))
+            print_section["PDOS"] = {
+                "LDOS": [
+                    {"COMPONENTS": "", "LIST": atom_index}
+                    for atom_index in range(1, self.ctx.n_atoms + 1)
+                ],
+                "NLUMO": added_mos,
+            }
+
     def run_sparse_overlap(self):
         if "sparse_overlap_code" not in self.inputs:
             return self.exit_codes.ERROR_MISSING_SPARSE_OVERLAP_CODE
@@ -233,6 +250,8 @@ class Cp2kScfWorkChain(Cp2kDiagWorkChain):
         builder.path = self.inputs.unfolding_path
         builder.lattice_type = self.inputs.unfolding_lattice_type
         builder.overlap_threshold = self.inputs.overlap_threshold
+        builder.parse_pdos_projections = orm.Bool(True)
+        builder.pdos_threshold = self.inputs.unfolding_pdos_threshold
         builder.metadata = {
             "label": "cp2k_unfolding",
             "options": {
@@ -323,6 +342,16 @@ class Cp2kScfWorkChain(Cp2kDiagWorkChain):
                 if output_filename not in retrieved_names:
                     self.report(f"CP2K band unfolding did not retrieve {output_filename}")
                     return self.exit_codes.ERROR_MISSING_UNFOLDING_OUTPUT
+                if self.ctx.unfolding.inputs.parse_pdos_projections.value:
+                    projection_filename = (
+                        self.ctx.unfolding.inputs.pdos_projection_filename.value
+                    )
+                    if projection_filename not in retrieved_names:
+                        self.report(
+                            "CP2K band unfolding did not retrieve "
+                            f"{projection_filename}"
+                        )
+                        return self.exit_codes.ERROR_MISSING_UNFOLDING_OUTPUT
                 self.out("unfolding_retrieved", self.ctx.unfolding.outputs.retrieved)
 
             self.out("output_parameters", self.ctx.diag_scf.outputs.output_parameters)

--- a/aiida_nanotech_empa/workflows/cp2k/scf_workchain.py
+++ b/aiida_nanotech_empa/workflows/cp2k/scf_workchain.py
@@ -1,0 +1,146 @@
+from aiida import engine, orm, plugins
+
+from ...utils import common_utils
+from .diag_workchain import Cp2kDiagWorkChain
+
+SparseOverlapCalculation = plugins.CalculationFactory("nanotech_empa.sparse_overlap")
+
+
+class Cp2kScfWorkChain(Cp2kDiagWorkChain):
+    @classmethod
+    def define(cls, spec):
+        super().define(spec)
+        spec.input(
+            "write_overlap_matrix",
+            valid_type=orm.Bool,
+            default=lambda: orm.Bool(False),
+            required=False,
+            help="Run the diagonalization SCF step and print the AO overlap matrix.",
+        )
+        spec.input(
+            "retrieve_sparse_overlap",
+            valid_type=orm.Bool,
+            default=lambda: orm.Bool(False),
+            required=False,
+            help="Post-process the remote AO overlap matrix and retrieve sparse entries.",
+        )
+        spec.input(
+            "sparse_overlap_code",
+            valid_type=orm.Code,
+            required=False,
+            help="Python code configured for the nanotech_empa.sparse_overlap plugin.",
+        )
+        spec.input(
+            "overlap_ndigits",
+            valid_type=orm.Int,
+            default=lambda: orm.Int(14),
+            required=False,
+            help="Number of digits for the printed AO overlap matrix.",
+        )
+        spec.input(
+            "overlap_threshold",
+            valid_type=orm.Float,
+            default=lambda: orm.Float(1.0e-10),
+            required=False,
+            help="Absolute-value threshold for retrieved sparse overlap entries.",
+        )
+        spec.outline(
+            cls.setup,
+            cls.run_ot_scf,
+            engine.if_(cls.should_run_diag_scf)(
+                cls.run_diag_scf,
+                engine.if_(cls.should_run_sparse_overlap)(
+                    cls.run_sparse_overlap,
+                ),
+            ),
+            cls.finalize,
+        )
+        spec.exit_code(
+            391,
+            "ERROR_MISSING_SPARSE_OVERLAP_CODE",
+            message="A sparse overlap code is required to retrieve sparse overlap entries.",
+        )
+
+    def should_run_diag_scf(self):
+        dft_params = self.inputs.dft_params.get_dict()
+        return (
+            self.inputs.write_overlap_matrix.value
+            or self.inputs.retrieve_sparse_overlap.value
+            or dft_params.get("added_mos", 0) > 0
+        )
+
+    def should_run_sparse_overlap(self):
+        return self.inputs.retrieve_sparse_overlap.value
+
+    def update_diag_input_dict(self, input_dict):
+        if not (
+            self.inputs.write_overlap_matrix.value
+            or self.inputs.retrieve_sparse_overlap.value
+        ):
+            return
+
+        print_section = input_dict["FORCE_EVAL"]["DFT"].setdefault("PRINT", {})
+        print_section["AO_MATRICES"] = {
+            "_": "ON",
+            "OVERLAP": "T",
+            "FILENAME": "overlap_matrix.out",
+            "NDIGITS": self.inputs.overlap_ndigits.value,
+        }
+
+    def run_sparse_overlap(self):
+        if "sparse_overlap_code" not in self.inputs:
+            return self.exit_codes.ERROR_MISSING_SPARSE_OVERLAP_CODE
+
+        self.report("Running sparse overlap post-processing")
+        builder = SparseOverlapCalculation.get_builder()
+        builder.code = self.inputs.sparse_overlap_code
+        builder.parent_calc_folder = self.ctx.diag_scf.outputs.remote_folder
+        builder.threshold = self.inputs.overlap_threshold
+        builder.matrix_filename = orm.Str("aiida-overlap_matrix.out-1_0.Log")
+        builder.output_filename = orm.Str("sparse_overlap.npz")
+        builder.metadata = {
+            "label": "sparse_overlap",
+            "options": {
+                "resources": {
+                    "num_machines": 1,
+                    "num_mpiprocs_per_machine": 1,
+                    "num_cores_per_mpiproc": 1,
+                },
+                "max_wallclock_seconds": min(
+                    3600, self.ctx.options["max_wallclock_seconds"]
+                ),
+                "withmpi": False,
+            },
+        }
+        return engine.ToContext(sparse_overlap=self.submit(builder))
+
+    def finalize(self):
+        if self.should_run_diag_scf():
+            if not common_utils.check_if_calc_ok(self, self.ctx.diag_scf):
+                self.report("diagonalization scf failed")
+                return self.exit_codes.ERROR_TERMINATION
+
+            if self.should_run_sparse_overlap():
+                if not common_utils.check_if_calc_ok(self, self.ctx.sparse_overlap):
+                    self.report("sparse overlap post-processing failed")
+                    return self.exit_codes.ERROR_TERMINATION
+                self.out(
+                    "sparse_overlap_retrieved",
+                    self.ctx.sparse_overlap.outputs.retrieved,
+                )
+
+            self.out("output_parameters", self.ctx.diag_scf.outputs.output_parameters)
+            self.out("remote_folder", self.ctx.diag_scf.outputs.remote_folder)
+            self.out("retrieved", self.ctx.diag_scf.outputs.retrieved)
+            self.report("Work chain is finished")
+            return None
+
+        if not common_utils.check_if_calc_ok(self, self.ctx.ot_scf):
+            self.report("OT SCF failed")
+            return self.exit_codes.ERROR_TERMINATION
+
+        self.out("output_parameters", self.ctx.ot_scf.outputs.output_parameters)
+        self.out("remote_folder", self.ctx.ot_scf.outputs.remote_folder)
+        self.out("retrieved", self.ctx.ot_scf.outputs.retrieved)
+        self.report("Work chain is finished")
+        return None

--- a/aiida_nanotech_empa/workflows/cp2k/scf_workchain.py
+++ b/aiida_nanotech_empa/workflows/cp2k/scf_workchain.py
@@ -204,7 +204,9 @@ class Cp2kScfWorkChain(Cp2kDiagWorkChain):
             self.out("output_parameters", self.ctx.ot_scf.outputs.output_parameters)
             self.out("remote_folder", self.ctx.ot_scf.outputs.remote_folder)
             self.out("retrieved", self.ctx.ot_scf.outputs.retrieved)
+            self.out("ot_retrieved", self.ctx.ot_scf.outputs.retrieved)
             self.out("bader_retrieved", self.ctx.bader.outputs.retrieved)
+            common_utils.add_extras(self.inputs.structure, "surfaces", self.node.uuid)
             self.report("Work chain is finished")
             return None
 
@@ -225,6 +227,8 @@ class Cp2kScfWorkChain(Cp2kDiagWorkChain):
             self.out("output_parameters", self.ctx.diag_scf.outputs.output_parameters)
             self.out("remote_folder", self.ctx.diag_scf.outputs.remote_folder)
             self.out("retrieved", self.ctx.diag_scf.outputs.retrieved)
+            self.out("ot_retrieved", self.ctx.ot_scf.outputs.retrieved)
+            common_utils.add_extras(self.inputs.structure, "surfaces", self.node.uuid)
             self.report("Work chain is finished")
             return None
 
@@ -235,5 +239,7 @@ class Cp2kScfWorkChain(Cp2kDiagWorkChain):
         self.out("output_parameters", self.ctx.ot_scf.outputs.output_parameters)
         self.out("remote_folder", self.ctx.ot_scf.outputs.remote_folder)
         self.out("retrieved", self.ctx.ot_scf.outputs.retrieved)
+        self.out("ot_retrieved", self.ctx.ot_scf.outputs.retrieved)
+        common_utils.add_extras(self.inputs.structure, "surfaces", self.node.uuid)
         self.report("Work chain is finished")
         return None

--- a/aiida_nanotech_empa/workflows/cp2k/scf_workchain.py
+++ b/aiida_nanotech_empa/workflows/cp2k/scf_workchain.py
@@ -136,6 +136,11 @@ class Cp2kScfWorkChain(Cp2kDiagWorkChain):
             "ERROR_MISSING_UNFOLDING_PRIMITIVE_VECTORS",
             message="Primitive vectors are required to compute band unfolding.",
         )
+        spec.exit_code(
+            395,
+            "ERROR_MISSING_UNFOLDING_OUTPUT",
+            message="CP2K band unfolding finished without retrieving unfolding_bands.npz.",
+        )
 
     def should_run_diag_scf(self):
         if self.should_run_bader():
@@ -311,6 +316,13 @@ class Cp2kScfWorkChain(Cp2kDiagWorkChain):
                 if not common_utils.check_if_calc_ok(self, self.ctx.unfolding):
                     self.report("CP2K band unfolding post-processing failed")
                     return self.exit_codes.ERROR_TERMINATION
+                output_filename = self.ctx.unfolding.inputs.output_filename.value
+                retrieved_names = (
+                    self.ctx.unfolding.outputs.retrieved.base.repository.list_object_names()
+                )
+                if output_filename not in retrieved_names:
+                    self.report(f"CP2K band unfolding did not retrieve {output_filename}")
+                    return self.exit_codes.ERROR_MISSING_UNFOLDING_OUTPUT
                 self.out("unfolding_retrieved", self.ctx.unfolding.outputs.retrieved)
 
             self.out("output_parameters", self.ctx.diag_scf.outputs.output_parameters)

--- a/conftest.py
+++ b/conftest.py
@@ -129,9 +129,7 @@ def cp2k_code(local_code_factory):
 
 @pytest.fixture(scope="function")
 def spm_code(local_code_factory):
-    return local_code_factory(
-        "nanotech_empa.stm", "cp2k-stm-sts-wfn", label="stm"
-    )
+    return local_code_factory("nanotech_empa.stm", "cp2k-stm-sts-wfn", label="stm")
 
 
 @pytest.fixture(scope="function")

--- a/examples/workflows/example_cp2k_hrstm.py
+++ b/examples/workflows/example_cp2k_hrstm.py
@@ -1,4 +1,5 @@
 import os
+
 import ase.io
 import click
 import numpy as np

--- a/examples/workflows/example_cp2k_mol_opt_gw.py
+++ b/examples/workflows/example_cp2k_mol_opt_gw.py
@@ -53,8 +53,7 @@ def _geo_opt_cp2k_builder(cp2k_code):
     )
 
     data_dir = (
-        pathlib.Path(__file__).parents[2]
-        / "aiida_nanotech_empa/workflows/cp2k/data"
+        pathlib.Path(__file__).parents[2] / "aiida_nanotech_empa/workflows/cp2k/data"
     )
 
     builder = Cp2kCalculation.get_builder()

--- a/examples/workflows/example_cp2k_neb.py
+++ b/examples/workflows/example_cp2k_neb.py
@@ -12,9 +12,7 @@ Cp2kNebWorkChain = plugins.WorkflowFactory("nanotech_empa.cp2k.neb")
 DATA_DIR = script_dir(__file__)
 
 
-def _example_cp2k_neb(
-    cp2k_code, uks, restart_uuid, n_nodes=1, n_cores_per_node=1
-):
+def _example_cp2k_neb(cp2k_code, uks, restart_uuid, n_nodes=1, n_cores_per_node=1):
     builder = Cp2kNebWorkChain.get_builder()
 
     builder.metadata.label = "CP2K_NEB"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ dev = [
 "nanotech_empa.overlap" = "aiida_nanotech_empa.plugins:OverlapCalculation"
 "nanotech_empa.sparse_overlap" = "aiida_nanotech_empa.plugins:SparseOverlapCalculation"
 "nanotech_empa.bader" = "aiida_nanotech_empa.plugins:BaderCalculation"
+"nanotech_empa.cp2k_unfolding" = "aiida_nanotech_empa.plugins:Cp2kUnfoldingCalculation"
 "nanotech_empa.afm" = "aiida_nanotech_empa.plugins:AfmCalculation"
 "nanotech_empa.hrstm" = "aiida_nanotech_empa.plugins:HrstmCalculation"
 "nanotech_empa.cubehandler" = "aiida_nanotech_empa.plugins:CubeHandlerCalculation"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ dev = [
 "nanotech_empa.stm" = "aiida_nanotech_empa.plugins:StmCalculation"
 "nanotech_empa.overlap" = "aiida_nanotech_empa.plugins:OverlapCalculation"
 "nanotech_empa.sparse_overlap" = "aiida_nanotech_empa.plugins:SparseOverlapCalculation"
+"nanotech_empa.bader" = "aiida_nanotech_empa.plugins:BaderCalculation"
 "nanotech_empa.afm" = "aiida_nanotech_empa.plugins:AfmCalculation"
 "nanotech_empa.hrstm" = "aiida_nanotech_empa.plugins:HrstmCalculation"
 "nanotech_empa.cubehandler" = "aiida_nanotech_empa.plugins:CubeHandlerCalculation"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ dev = [
 [project.entry-points."aiida.calculations"]
 "nanotech_empa.stm" = "aiida_nanotech_empa.plugins:StmCalculation"
 "nanotech_empa.overlap" = "aiida_nanotech_empa.plugins:OverlapCalculation"
+"nanotech_empa.sparse_overlap" = "aiida_nanotech_empa.plugins:SparseOverlapCalculation"
 "nanotech_empa.afm" = "aiida_nanotech_empa.plugins:AfmCalculation"
 "nanotech_empa.hrstm" = "aiida_nanotech_empa.plugins:HrstmCalculation"
 "nanotech_empa.cubehandler" = "aiida_nanotech_empa.plugins:CubeHandlerCalculation"
@@ -84,6 +85,7 @@ dev = [
 "nanotech_empa.cp2k.afm" = "aiida_nanotech_empa.workflows.cp2k:Cp2kAfmWorkChain"
 "nanotech_empa.cp2k.hrstm" = "aiida_nanotech_empa.workflows.cp2k:Cp2kHrstmWorkChain"
 "nanotech_empa.cp2k.diag" = "aiida_nanotech_empa.workflows.cp2k:Cp2kDiagWorkChain"
+"nanotech_empa.cp2k.scf" = "aiida_nanotech_empa.workflows.cp2k:Cp2kScfWorkChain"
 "nanotech_empa.cp2k.replica" = "aiida_nanotech_empa.workflows.cp2k:Cp2kReplicaWorkChain"
 "nanotech_empa.cp2k.neb" = "aiida_nanotech_empa.workflows.cp2k:Cp2kNebWorkChain"
 "nanotech_empa.cp2k.phonons" = "aiida_nanotech_empa.workflows.cp2k:Cp2kPhononsWorkChain"


### PR DESCRIPTION
## Summary
- add `nanotech_empa.cp2k.scf` for OT-only SCF, optional diagonalization/ADDED_MOS, AO overlap printing, sparse AO-overlap post-processing, and Bader analysis
- add `nanotech_empa.sparse_overlap` and `nanotech_empa.bader` CalcJob plugins
- expose SCF results to the surfaces search workflow via structure extras and `ot_retrieved`
- refresh the package README contents

## Validation
- tested SCF overlap and sparse retrieval workflows, including UKS/ADDED_MOS, with successful AiiDA runs
- tested Bader mode with successful run PK 3649
- standalone Bader CalcJob test PK 3633 retrieved `ACF.dat`, `AVF.dat`, `BCF.dat`
- ran Python compile checks and AiiDA plugin import checks

## Related PRs
- surfaces notebook/search integration: nanotech-empa/aiidalab-empa-surfaces#276
- reusable sparse overlap converter: nanotech-empa/useful-notebooks#5