### PR TITLE
PR-A1: CP2K SCF overlap workchain

### DIFF
--- a/aiida_nanotech_empa/plugins/__init__.py
+++ b/aiida_nanotech_empa/plugins/__init__.py
@@ -2,6 +2,7 @@ from .afm import AfmCalculation
 from .cubehandler import CubeHandlerCalculation
 from .hrstm import HrstmCalculation
 from .overlap import OverlapCalculation
+from .sparse_overlap import SparseOverlapCalculation
 from .stm import StmCalculation
 
 __all__ = (
@@ -9,5 +10,6 @@ __all__ = (
     "CubeHandlerCalculation",
     "HrstmCalculation",
     "OverlapCalculation",
+    "SparseOverlapCalculation",
     "StmCalculation",
 )

--- a/aiida_nanotech_empa/plugins/sparse_overlap.py
+++ b/aiida_nanotech_empa/plugins/sparse_overlap.py
@@ -1,0 +1,79 @@
+from aiida import common, engine, orm
+
+
+DEFAULT_MATRIX_FILENAME = "aiida-overlap_matrix.out-1_0.Log"
+DEFAULT_OUTPUT_FILENAME = "sparse_overlap.npz"
+
+
+class SparseOverlapCalculation(engine.CalcJob):
+    @classmethod
+    def define(cls, spec):
+        super().define(spec)
+        spec.input(
+            "parent_calc_folder",
+            valid_type=orm.RemoteData,
+            help="CP2K folder with the AO overlap matrix log file.",
+        )
+        spec.input(
+            "threshold",
+            valid_type=orm.Float,
+            default=lambda: orm.Float(1.0e-10),
+            required=False,
+            help="Store matrix elements whose absolute value is larger than this threshold.",
+        )
+        spec.input(
+            "matrix_filename",
+            valid_type=orm.Str,
+            default=lambda: orm.Str(DEFAULT_MATRIX_FILENAME),
+            required=False,
+        )
+        spec.input(
+            "output_filename",
+            valid_type=orm.Str,
+            default=lambda: orm.Str(DEFAULT_OUTPUT_FILENAME),
+            required=False,
+        )
+        spec.input(
+            "settings",
+            valid_type=orm.Dict,
+            default=lambda: orm.Dict(dict={}),
+            required=False,
+        )
+        spec.input("metadata.options.withmpi", valid_type=bool, default=False)
+
+    def prepare_for_submission(self, folder):
+        settings = self.inputs.settings.get_dict() if "settings" in self.inputs else {}
+
+        output_filename = self.inputs.output_filename.value
+        codeinfo = common.CodeInfo()
+        codeinfo.code_uuid = self.inputs.code.uuid
+        codeinfo.cmdline_params = [
+            "parent_calc_folder/" + self.inputs.matrix_filename.value,
+            output_filename,
+            "--threshold",
+            str(self.inputs.threshold.value),
+        ]
+
+        calcinfo = common.CalcInfo()
+        calcinfo.uuid = self.uuid
+        calcinfo.codes_info = [codeinfo]
+        calcinfo.remote_symlink_list = []
+        calcinfo.remote_copy_list = []
+        calcinfo.local_copy_list = []
+        calcinfo.retrieve_list = settings.pop("additional_retrieve_list", [output_filename])
+
+        comp_uuid = self.inputs.parent_calc_folder.computer.uuid
+        remote_path = self.inputs.parent_calc_folder.get_remote_path()
+        copy_info = (comp_uuid, remote_path, "parent_calc_folder/")
+        if self.inputs.code.computer.uuid == comp_uuid:
+            calcinfo.remote_symlink_list.append(copy_info)
+        else:
+            calcinfo.remote_copy_list.append(copy_info)
+
+        if settings:
+            raise common.InputValidationError(
+                "The following keys have been found in settings but were not understood: "
+                + ",".join(settings.keys())
+            )
+
+        return calcinfo

--- a/aiida_nanotech_empa/plugins/sparse_overlap.py
+++ b/aiida_nanotech_empa/plugins/sparse_overlap.py
@@ -60,7 +60,9 @@ class SparseOverlapCalculation(engine.CalcJob):
         calcinfo.remote_symlink_list = []
         calcinfo.remote_copy_list = []
         calcinfo.local_copy_list = []
-        calcinfo.retrieve_list = settings.pop("additional_retrieve_list", [output_filename])
+        calcinfo.retrieve_list = settings.pop(
+            "additional_retrieve_list", [output_filename]
+        )
 
         comp_uuid = self.inputs.parent_calc_folder.computer.uuid
         remote_path = self.inputs.parent_calc_folder.get_remote_path()

--- a/aiida_nanotech_empa/workflows/cp2k/__init__.py
+++ b/aiida_nanotech_empa/workflows/cp2k/__init__.py
@@ -12,6 +12,7 @@ from .pdos_workchain import Cp2kPdosWorkChain
 from .phonons_workchain import Cp2kPhononsWorkChain
 from .reftraj_md_workchain import Cp2kRefTrajWorkChain
 from .replica_workchain import Cp2kReplicaWorkChain
+from .scf_workchain import Cp2kScfWorkChain
 from .stm_workchain import Cp2kStmWorkChain
 
 __all__ = (
@@ -26,6 +27,7 @@ __all__ = (
     "Cp2kAfmWorkChain",
     "Cp2kHrstmWorkChain",
     "Cp2kDiagWorkChain",
+    "Cp2kScfWorkChain",
     "Cp2kReplicaWorkChain",
     "Cp2kNebWorkChain",
     "Cp2kPhononsWorkChain",

--- a/aiida_nanotech_empa/workflows/cp2k/diag_workchain.py
+++ b/aiida_nanotech_empa/workflows/cp2k/diag_workchain.py
@@ -11,10 +11,12 @@ Cp2kBaseWorkChain = plugins.WorkflowFactory("cp2k.base")
 
 
 class Cp2kDiagWorkChain(engine.WorkChain):
+
     @classmethod
     def define(cls, spec):
         super().define(spec)
 
+        # Define the inputs of the work chain.
         spec.input("cp2k_code", valid_type=orm.Code)
         spec.input("structure", valid_type=orm.StructureData)
         spec.input("parent_calc_folder", valid_type=orm.RemoteData, required=False)
@@ -45,6 +47,8 @@ class Cp2kDiagWorkChain(engine.WorkChain):
             help="Define options for the cacluations: walltime, memory, CPUs, etc.",
         )
         cp2k_utils.add_restart_policy_inputs(spec)
+
+        # Define the outline of the work chain.
         spec.outline(
             cls.setup,
             cls.run_ot_scf,
@@ -52,6 +56,7 @@ class Cp2kDiagWorkChain(engine.WorkChain):
             cls.finalize,
         )
 
+        # Define the outputs of the work chain.
         spec.outputs.dynamic = True
 
         spec.exit_code(
@@ -75,6 +80,10 @@ class Cp2kDiagWorkChain(engine.WorkChain):
         self.ctx.n_atoms = len(structure.sites)
 
         self.ctx.dft_params = self.inputs.dft_params.get_dict()
+        self.ctx.dft_params.setdefault("periodic", "XYZ")
+        self.ctx.dft_params.setdefault("uks", False)
+        self.ctx.dft_params.setdefault("elpa_switch", False)
+        self.ctx.dft_params.setdefault("sc_diag", False)
 
         # Resources.
         self.ctx.options = self.inputs.options.get_dict()
@@ -244,6 +253,8 @@ class Cp2kDiagWorkChain(engine.WorkChain):
             )
             input_dict["FORCE_EVAL"]["DFT"]["PRINT"]["MO_CUBES"]["STRIDE"] = "2 2 2"
 
+        self.update_diag_input_dict(input_dict)
+
         # Setup walltime.
         input_dict["GLOBAL"]["WALLTIME"] = max(
             600, self.ctx.options["max_wallclock_seconds"] - 600
@@ -284,3 +295,6 @@ class Cp2kDiagWorkChain(engine.WorkChain):
         self.out("remote_folder", self.ctx.diag_scf.outputs.remote_folder)
         self.out("retrieved", self.ctx.diag_scf.outputs.retrieved)
         self.report("Work chain is finished")
+
+    def update_diag_input_dict(self, input_dict):
+        """Hook for derived workchains to add diagonalization-only CP2K input."""

--- a/aiida_nanotech_empa/workflows/cp2k/diag_workchain.py
+++ b/aiida_nanotech_empa/workflows/cp2k/diag_workchain.py
@@ -11,7 +11,6 @@ Cp2kBaseWorkChain = plugins.WorkflowFactory("cp2k.base")
 
 
 class Cp2kDiagWorkChain(engine.WorkChain):
-
     @classmethod
     def define(cls, spec):
         super().define(spec)

--- a/aiida_nanotech_empa/workflows/cp2k/diag_workchain.py
+++ b/aiida_nanotech_empa/workflows/cp2k/diag_workchain.py
@@ -15,7 +15,6 @@ class Cp2kDiagWorkChain(engine.WorkChain):
     def define(cls, spec):
         super().define(spec)
 
-        # Define the inputs of the work chain.
         spec.input("cp2k_code", valid_type=orm.Code)
         spec.input("structure", valid_type=orm.StructureData)
         spec.input("parent_calc_folder", valid_type=orm.RemoteData, required=False)
@@ -47,7 +46,6 @@ class Cp2kDiagWorkChain(engine.WorkChain):
         )
         cp2k_utils.add_restart_policy_inputs(spec)
 
-        # Define the outline of the work chain.
         spec.outline(
             cls.setup,
             cls.run_ot_scf,
@@ -55,7 +53,6 @@ class Cp2kDiagWorkChain(engine.WorkChain):
             cls.finalize,
         )
 
-        # Define the outputs of the work chain.
         spec.outputs.dynamic = True
 
         spec.exit_code(

--- a/aiida_nanotech_empa/workflows/cp2k/scf_workchain.py
+++ b/aiida_nanotech_empa/workflows/cp2k/scf_workchain.py
@@ -7,6 +7,10 @@ SparseOverlapCalculation = plugins.CalculationFactory("nanotech_empa.sparse_over
 
 
 class Cp2kScfWorkChain(Cp2kDiagWorkChain):
+    """Extends `Cp2kDiagWorkChain`, making the diagonalization step optional
+    and adding the option to print/retrieve the AO overlap matrix.
+    """
+
     @classmethod
     def define(cls, spec):
         super().define(spec)
@@ -90,6 +94,8 @@ class Cp2kScfWorkChain(Cp2kDiagWorkChain):
         print_section["AO_MATRICES"] = {
             "_": "ON",
             "OVERLAP": "T",
+            # CP2K/aiida-cp2k retrieve this as "aiida-overlap_matrix.out-1_0.Log",
+            # matching SparseOverlapCalculation's default matrix_filename.
             "FILENAME": "overlap_matrix.out",
             "NDIGITS": self.inputs.overlap_ndigits.value,
         }

--- a/aiida_nanotech_empa/workflows/cp2k/scf_workchain.py
+++ b/aiida_nanotech_empa/workflows/cp2k/scf_workchain.py
@@ -1,0 +1,146 @@
+from aiida import engine, orm, plugins
+
+from ...utils import common_utils
+from .diag_workchain import Cp2kDiagWorkChain
+
+SparseOverlapCalculation = plugins.CalculationFactory("nanotech_empa.sparse_overlap")
+
+
+class Cp2kScfWorkChain(Cp2kDiagWorkChain):
+    @classmethod
+    def define(cls, spec):
+        super().define(spec)
+        spec.input(
+            "write_overlap_matrix",
+            valid_type=orm.Bool,
+            default=lambda: orm.Bool(False),
+            required=False,
+            help="Run the diagonalization SCF step and print the AO overlap matrix.",
+        )
+        spec.input(
+            "retrieve_sparse_overlap",
+            valid_type=orm.Bool,
+            default=lambda: orm.Bool(False),
+            required=False,
+            help="Post-process the remote AO overlap matrix and retrieve sparse entries.",
+        )
+        spec.input(
+            "sparse_overlap_code",
+            valid_type=orm.Code,
+            required=False,
+            help="Python code configured for the nanotech_empa.sparse_overlap plugin.",
+        )
+        spec.input(
+            "overlap_ndigits",
+            valid_type=orm.Int,
+            default=lambda: orm.Int(14),
+            required=False,
+            help="Number of digits for the printed AO overlap matrix.",
+        )
+        spec.input(
+            "overlap_threshold",
+            valid_type=orm.Float,
+            default=lambda: orm.Float(1.0e-10),
+            required=False,
+            help="Absolute-value threshold for retrieved sparse overlap entries.",
+        )
+        spec.outline(
+            cls.setup,
+            cls.run_ot_scf,
+            engine.if_(cls.should_run_diag_scf)(
+                cls.run_diag_scf,
+                engine.if_(cls.should_run_sparse_overlap)(
+                    cls.run_sparse_overlap,
+                ),
+            ),
+            cls.finalize,
+        )
+        spec.exit_code(
+            391,
+            "ERROR_MISSING_SPARSE_OVERLAP_CODE",
+            message="A sparse overlap code is required to retrieve sparse overlap entries.",
+        )
+
+    def should_run_diag_scf(self):
+        dft_params = self.inputs.dft_params.get_dict()
+        return (
+            self.inputs.write_overlap_matrix.value
+            or self.inputs.retrieve_sparse_overlap.value
+            or dft_params.get("added_mos", 0) > 0
+        )
+
+    def should_run_sparse_overlap(self):
+        return self.inputs.retrieve_sparse_overlap.value
+
+    def update_diag_input_dict(self, input_dict):
+        if not (
+            self.inputs.write_overlap_matrix.value
+            or self.inputs.retrieve_sparse_overlap.value
+        ):
+            return
+
+        print_section = input_dict["FORCE_EVAL"]["DFT"].setdefault("PRINT", {})
+        print_section["AO_MATRICES"] = {
+            "_": "ON",
+            "OVERLAP": "T",
+            "FILENAME": "overlap_matrix.out",
+            "NDIGITS": self.inputs.overlap_ndigits.value,
+        }
+
+    def run_sparse_overlap(self):
+        if "sparse_overlap_code" not in self.inputs:
+            return self.exit_codes.ERROR_MISSING_SPARSE_OVERLAP_CODE
+
+        self.report("Running sparse overlap post-processing")
+        builder = SparseOverlapCalculation.get_builder()
+        builder.code = self.inputs.sparse_overlap_code
+        builder.parent_calc_folder = self.ctx.diag_scf.outputs.remote_folder
+        builder.threshold = self.inputs.overlap_threshold
+        builder.matrix_filename = orm.Str("aiida-overlap_matrix.out-1_0.Log")
+        builder.output_filename = orm.Str("sparse_overlap.npz")
+        builder.metadata = {
+            "label": "sparse_overlap",
+            "options": {
+                "resources": {
+                    "num_machines": 1,
+                    "num_mpiprocs_per_machine": 1,
+                    "num_cores_per_mpiproc": 1,
+                },
+                "max_wallclock_seconds": min(
+                    3600, self.ctx.options["max_wallclock_seconds"]
+                ),
+                "withmpi": False,
+            },
+        }
+        return engine.ToContext(sparse_overlap=self.submit(builder))
+
+    def finalize(self):
+        if self.should_run_diag_scf():
+            if not common_utils.check_if_calc_ok(self, self.ctx.diag_scf):
+                self.report("diagonalization scf failed")
+                return self.exit_codes.ERROR_TERMINATION
+
+            if self.should_run_sparse_overlap():
+                if not common_utils.check_if_calc_ok(self, self.ctx.sparse_overlap):
+                    self.report("sparse overlap post-processing failed")
+                    return self.exit_codes.ERROR_TERMINATION
+                self.out(
+                    "sparse_overlap_retrieved",
+                    self.ctx.sparse_overlap.outputs.retrieved,
+                )
+
+            self.out("output_parameters", self.ctx.diag_scf.outputs.output_parameters)
+            self.out("remote_folder", self.ctx.diag_scf.outputs.remote_folder)
+            self.out("retrieved", self.ctx.diag_scf.outputs.retrieved)
+            self.report("Work chain is finished")
+            return None
+
+        if not common_utils.check_if_calc_ok(self, self.ctx.ot_scf):
+            self.report("OT SCF failed")
+            return self.exit_codes.ERROR_TERMINATION
+
+        self.out("output_parameters", self.ctx.ot_scf.outputs.output_parameters)
+        self.out("remote_folder", self.ctx.ot_scf.outputs.remote_folder)
+        self.out("retrieved", self.ctx.ot_scf.outputs.retrieved)
+        self.report("Work chain is finished")
+        return None

--- a/aiida_nanotech_empa/workflows/cp2k/scf_workchain.py
+++ b/aiida_nanotech_empa/workflows/cp2k/scf_workchain.py
@@ -119,32 +119,23 @@ class Cp2kScfWorkChain(Cp2kDiagWorkChain):
         return engine.ToContext(sparse_overlap=self.submit(builder))
 
     def finalize(self):
-        if self.should_run_diag_scf():
-            if not common_utils.check_if_calc_ok(self, self.ctx.diag_scf):
-                self.report("diagonalization scf failed")
-                return self.exit_codes.ERROR_TERMINATION
+        run_diag = self.should_run_diag_scf()
+        final_calc = self.ctx.diag_scf if run_diag else self.ctx.ot_scf
+        calc_label = "diagonalization scf" if run_diag else "OT SCF"
 
-            if self.should_run_sparse_overlap():
-                if not common_utils.check_if_calc_ok(self, self.ctx.sparse_overlap):
-                    self.report("sparse overlap post-processing failed")
-                    return self.exit_codes.ERROR_TERMINATION
-                self.out(
-                    "sparse_overlap_retrieved",
-                    self.ctx.sparse_overlap.outputs.retrieved,
-                )
-
-            self.out("output_parameters", self.ctx.diag_scf.outputs.output_parameters)
-            self.out("remote_folder", self.ctx.diag_scf.outputs.remote_folder)
-            self.out("retrieved", self.ctx.diag_scf.outputs.retrieved)
-            self.report("Work chain is finished")
-            return None
-
-        if not common_utils.check_if_calc_ok(self, self.ctx.ot_scf):
-            self.report("OT SCF failed")
+        if not common_utils.check_if_calc_ok(self, final_calc):
+            self.report(f"{calc_label} failed")
             return self.exit_codes.ERROR_TERMINATION
 
-        self.out("output_parameters", self.ctx.ot_scf.outputs.output_parameters)
-        self.out("remote_folder", self.ctx.ot_scf.outputs.remote_folder)
-        self.out("retrieved", self.ctx.ot_scf.outputs.retrieved)
+        if run_diag and self.should_run_sparse_overlap():
+            if not common_utils.check_if_calc_ok(self, self.ctx.sparse_overlap):
+                self.report("sparse overlap post-processing failed")
+                return self.exit_codes.ERROR_TERMINATION
+            self.out(
+                "sparse_overlap_retrieved", self.ctx.sparse_overlap.outputs.retrieved
+            )
+
+        self.out("output_parameters", final_calc.outputs.output_parameters)
+        self.out("remote_folder", final_calc.outputs.remote_folder)
+        self.out("retrieved", final_calc.outputs.retrieved)
         self.report("Work chain is finished")
-        return None

--- a/aiida_nanotech_empa/workflows/cp2k/scf_workchain.py
+++ b/aiida_nanotech_empa/workflows/cp2k/scf_workchain.py
@@ -100,8 +100,6 @@ class Cp2kScfWorkChain(Cp2kDiagWorkChain):
         builder.code = self.inputs.sparse_overlap_code
         builder.parent_calc_folder = self.ctx.diag_scf.outputs.remote_folder
         builder.threshold = self.inputs.overlap_threshold
-        builder.matrix_filename = orm.Str("aiida-overlap_matrix.out-1_0.Log")
-        builder.output_filename = orm.Str("sparse_overlap.npz")
         builder.metadata = {
             "label": "sparse_overlap",
             "options": {

--- a/aiida_nanotech_empa/workflows/cp2k/scf_workchain.py
+++ b/aiida_nanotech_empa/workflows/cp2k/scf_workchain.py
@@ -55,11 +55,18 @@ class Cp2kScfWorkChain(Cp2kDiagWorkChain):
             ),
             cls.finalize,
         )
-        spec.exit_code(
-            391,
-            "ERROR_MISSING_SPARSE_OVERLAP_CODE",
-            message="A sparse overlap code is required to retrieve sparse overlap entries.",
-        )
+        spec.inputs.validator = staticmethod(cls._validate_inputs)
+
+    @staticmethod
+    def _validate_inputs(value, port_namespace):
+        if (
+            value["retrieve_sparse_overlap"].value
+            and "sparse_overlap_code" not in value
+        ):
+            return (
+                "'sparse_overlap_code' is required when "
+                "'retrieve_sparse_overlap' is True."
+            )
 
     def should_run_diag_scf(self):
         dft_params = self.inputs.dft_params.get_dict()
@@ -88,9 +95,6 @@ class Cp2kScfWorkChain(Cp2kDiagWorkChain):
         }
 
     def run_sparse_overlap(self):
-        if "sparse_overlap_code" not in self.inputs:
-            return self.exit_codes.ERROR_MISSING_SPARSE_OVERLAP_CODE
-
         self.report("Running sparse overlap post-processing")
         builder = SparseOverlapCalculation.get_builder()
         builder.code = self.inputs.sparse_overlap_code

--- a/aiida_nanotech_empa/workflows/cp2k/scf_workchain.py
+++ b/aiida_nanotech_empa/workflows/cp2k/scf_workchain.py
@@ -59,7 +59,7 @@ class Cp2kScfWorkChain(Cp2kDiagWorkChain):
             ),
             cls.finalize,
         )
-        spec.inputs.validator = staticmethod(cls._validate_inputs)
+        spec.inputs.validator = cls._validate_inputs
 
     @staticmethod
     def _validate_inputs(value, port_namespace):

--- a/conftest.py
+++ b/conftest.py
@@ -123,8 +123,11 @@ def qe_projwfc_code(local_code_factory):
 
 @pytest.fixture(scope="function")
 def cp2k_code(local_code_factory):
+    executable = "cp2k.ssmp" if shutil.which("cp2k.ssmp") else "cp2k"
+    if not shutil.which(executable):
+        pytest.skip("CP2K executable not available")
     prepend_text = "export OMP_NUM_THREADS=2"
-    return local_code_factory("cp2k", "cp2k.ssmp", prepend_text=prepend_text)
+    return local_code_factory("cp2k", executable, prepend_text=prepend_text)
 
 
 @pytest.fixture(scope="function")
@@ -136,4 +139,15 @@ def spm_code(local_code_factory):
 def overlap_code(local_code_factory):
     return local_code_factory(
         "nanotech_empa.overlap", "cp2k-overlap-from-wfns", label="overlap"
+    )
+
+
+@pytest.fixture(scope="function")
+def sparse_overlap_code(local_code_factory):
+    if not shutil.which("cp2k-overlap-to-sparse-npz"):
+        pytest.skip("cp2k-overlap-to-sparse-npz executable not available")
+    return local_code_factory(
+        "nanotech_empa.sparse_overlap",
+        "cp2k-overlap-to-sparse-npz",
+        label="sparse_overlap",
     )

--- a/examples/workflows/example_cp2k_scf_overlap.py
+++ b/examples/workflows/example_cp2k_scf_overlap.py
@@ -1,0 +1,82 @@
+import numpy as np
+import click
+from ase import Atoms
+from aiida import engine, orm, plugins
+
+Cp2kScfWorkChain = plugins.WorkflowFactory("nanotech_empa.cp2k.scf")
+
+
+def methane_structure():
+    center = np.array([4.0, 4.0, 4.0])
+    delta = 1.09 / np.sqrt(3.0)
+    offsets = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [delta, delta, delta],
+            [delta, -delta, -delta],
+            [-delta, delta, -delta],
+            [-delta, -delta, delta],
+        ]
+    )
+    atoms = Atoms(
+        "CH4",
+        positions=center + offsets,
+        cell=[8.0, 8.0, 8.0],
+        pbc=True,
+    )
+    return orm.StructureData(ase=atoms)
+
+
+def run_example(cp2k_code, sparse_overlap_code, n_nodes=1, n_cores_per_node=1):
+    builder = Cp2kScfWorkChain.get_builder()
+    builder.metadata.label = "Cp2kScfWorkChain CH4 sparse overlap example"
+    builder.cp2k_code = cp2k_code
+    builder.sparse_overlap_code = sparse_overlap_code
+    builder.structure = methane_structure()
+    builder.protocol = orm.Str("debug")
+    builder.dft_params = orm.Dict(dict={"periodic": "XYZ", "cutoff": 150})
+    builder.options = orm.Dict(
+        dict={
+            "max_wallclock_seconds": 600,
+            "resources": {
+                "num_machines": n_nodes,
+                "num_mpiprocs_per_machine": n_cores_per_node,
+                "num_cores_per_mpiproc": 1,
+            },
+        }
+    )
+    builder.retrieve_sparse_overlap = orm.Bool(True)
+    builder.overlap_threshold = orm.Float(1.0e-10)
+
+    _, node = engine.run_get_node(builder)
+
+    print(f"WorkChain PK: {node.pk}")
+    print(f"Finished OK: {node.is_finished_ok}")
+    if not node.is_finished_ok:
+        print(f"Exit status: {node.exit_status}")
+        print(f"Exit message: {node.exit_message}")
+        return node
+
+    retrieved = node.outputs.sparse_overlap_retrieved
+    names = retrieved.base.repository.list_object_names()
+    print("Sparse overlap retrieved files:", names)
+    assert "sparse_overlap.npz" in names
+    return node
+
+
+@click.command("cli")
+@click.argument("cp2k_code", default="cp2k@localhost")
+@click.argument("sparse_overlap_code", default="sparse_overlap@localhost")
+@click.option("-n", "--n-nodes", default=1, show_default=True)
+@click.option("-c", "--n-cores-per-node", default=1, show_default=True)
+def main(cp2k_code, sparse_overlap_code, n_nodes, n_cores_per_node):
+    run_example(
+        cp2k_code=orm.load_code(cp2k_code),
+        sparse_overlap_code=orm.load_code(sparse_overlap_code),
+        n_nodes=n_nodes,
+        n_cores_per_node=n_cores_per_node,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ dev = [
 [project.entry-points."aiida.calculations"]
 "nanotech_empa.stm" = "aiida_nanotech_empa.plugins:StmCalculation"
 "nanotech_empa.overlap" = "aiida_nanotech_empa.plugins:OverlapCalculation"
+"nanotech_empa.sparse_overlap" = "aiida_nanotech_empa.plugins:SparseOverlapCalculation"
 "nanotech_empa.afm" = "aiida_nanotech_empa.plugins:AfmCalculation"
 "nanotech_empa.hrstm" = "aiida_nanotech_empa.plugins:HrstmCalculation"
 "nanotech_empa.cubehandler" = "aiida_nanotech_empa.plugins:CubeHandlerCalculation"
@@ -86,6 +87,7 @@ dev = [
 "nanotech_empa.cp2k.afm" = "aiida_nanotech_empa.workflows.cp2k:Cp2kAfmWorkChain"
 "nanotech_empa.cp2k.hrstm" = "aiida_nanotech_empa.workflows.cp2k:Cp2kHrstmWorkChain"
 "nanotech_empa.cp2k.diag" = "aiida_nanotech_empa.workflows.cp2k:Cp2kDiagWorkChain"
+"nanotech_empa.cp2k.scf" = "aiida_nanotech_empa.workflows.cp2k:Cp2kScfWorkChain"
 "nanotech_empa.cp2k.replica" = "aiida_nanotech_empa.workflows.cp2k:Cp2kReplicaWorkChain"
 "nanotech_empa.cp2k.neb" = "aiida_nanotech_empa.workflows.cp2k:Cp2kNebWorkChain"
 "nanotech_empa.cp2k.phonons" = "aiida_nanotech_empa.workflows.cp2k:Cp2kPhononsWorkChain"

--- a/tests/test_scf_workchain.py
+++ b/tests/test_scf_workchain.py
@@ -1,0 +1,73 @@
+import numpy as np
+from ase import Atoms
+from aiida import engine, orm, plugins
+
+Cp2kScfWorkChain = plugins.WorkflowFactory("nanotech_empa.cp2k.scf")
+
+
+def _methane_structure():
+    center = np.array([4.0, 4.0, 4.0])
+    delta = 1.09 / np.sqrt(3.0)
+    offsets = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [delta, delta, delta],
+            [delta, -delta, -delta],
+            [-delta, delta, -delta],
+            [-delta, -delta, delta],
+        ]
+    )
+    atoms = Atoms(
+        "CH4",
+        positions=center + offsets,
+        cell=[8.0, 8.0, 8.0],
+        pbc=True,
+    )
+    return orm.StructureData(ase=atoms)
+
+
+def test_retrieve_sparse_overlap_requires_sparse_overlap_code():
+    message = Cp2kScfWorkChain._validate_inputs(
+        {"retrieve_sparse_overlap": orm.Bool(True)}, None
+    )
+
+    assert "sparse_overlap_code" in message
+
+
+def test_cp2k_scf_workchain_retrieves_sparse_overlap(
+    aiida_profile, cp2k_code, sparse_overlap_code
+):
+    builder = Cp2kScfWorkChain.get_builder()
+    builder.metadata.label = "Cp2kScfWorkChain CH4 sparse overlap test"
+    builder.cp2k_code = cp2k_code
+    builder.sparse_overlap_code = sparse_overlap_code
+    builder.structure = _methane_structure()
+    builder.protocol = orm.Str("debug")
+    builder.dft_params = orm.Dict(dict={"periodic": "XYZ", "cutoff": 150})
+    builder.options = orm.Dict(
+        dict={
+            "max_wallclock_seconds": 600,
+            "resources": {
+                "num_machines": 1,
+                "num_mpiprocs_per_machine": 1,
+                "num_cores_per_mpiproc": 1,
+            },
+        }
+    )
+    builder.retrieve_sparse_overlap = orm.Bool(True)
+    builder.overlap_threshold = orm.Float(1.0e-10)
+
+    _, node = engine.run_get_node(builder)
+
+    assert node.is_finished_ok
+    retrieved = node.outputs.sparse_overlap_retrieved
+    assert "sparse_overlap.npz" in retrieved.base.repository.list_object_names()
+
+    with retrieved.base.repository.open("sparse_overlap.npz", "rb") as handle:
+        with np.load(handle) as sparse_overlap:
+            shape = tuple(sparse_overlap["shape"])
+            elements = set(sparse_overlap["element"].astype(str))
+            assert shape[0] == shape[1]
+            assert shape[0] == sparse_overlap["basis_index"].size
+            assert sparse_overlap["data"].size >= shape[0]
+            assert {"C", "H"} <= elements


### PR DESCRIPTION
Part of the aiida-nanotech-empa split-PR chain extracted from the full working reference branch feature/cp2k-dft-protocol-refactor.

This PR starts the CP2K SCF stack on top of aiida-core-2.8.

Scope:
- add SparseOverlapCalculation CalcJob and entry point;
- add Cp2kScfWorkChain and workflow entry point;
- extend Cp2kDiagWorkChain with optional overlap-matrix writing/retrieval hooks needed by SCF;
- keep this limited to the original SCF overlap workchain commit.

Files touched:
- aiida_nanotech_empa/plugins/__init__.py
- aiida_nanotech_empa/plugins/sparse_overlap.py
- aiida_nanotech_empa/workflows/cp2k/__init__.py
- aiida_nanotech_empa/workflows/cp2k/diag_workchain.py
- aiida_nanotech_empa/workflows/cp2k/scf_workchain.py
- pyproject.toml

Validation:
- python -m py_compile on sparse_overlap.py, scf_workchain.py, and diag_workchain.py
- compared file list/stat against commit e5227f8 from the full reference history.