### PR TITLE
PR-A2: Bader analysis for CP2K SCF

### DIFF
--- a/aiida_nanotech_empa/plugins/__init__.py
+++ b/aiida_nanotech_empa/plugins/__init__.py
@@ -1,4 +1,5 @@
 from .afm import AfmCalculation
+from .bader import BaderCalculation
 from .cubehandler import CubeHandlerCalculation
 from .hrstm import HrstmCalculation
 from .overlap import OverlapCalculation
@@ -7,6 +8,7 @@ from .stm import StmCalculation
 
 __all__ = (
     "AfmCalculation",
+    "BaderCalculation",
     "CubeHandlerCalculation",
     "HrstmCalculation",
     "OverlapCalculation",

--- a/aiida_nanotech_empa/plugins/__init__.py
+++ b/aiida_nanotech_empa/plugins/__init__.py
@@ -2,6 +2,7 @@ from .afm import AfmCalculation
 from .cubehandler import CubeHandlerCalculation
 from .hrstm import HrstmCalculation
 from .overlap import OverlapCalculation
+from .sparse_overlap import SparseOverlapCalculation
 from .stm import StmCalculation
 
 __all__ = (
@@ -9,5 +10,6 @@ __all__ = (
     "CubeHandlerCalculation",
     "HrstmCalculation",
     "OverlapCalculation",
+    "SparseOverlapCalculation",
     "StmCalculation",
 )

--- a/aiida_nanotech_empa/plugins/bader.py
+++ b/aiida_nanotech_empa/plugins/bader.py
@@ -1,0 +1,64 @@
+from aiida import common, engine, orm
+
+
+DEFAULT_CHARGE_DENSITY_FILENAME = "aiida-ELECTRON_DENSITY-1_0.cube"
+DEFAULT_RETRIEVE_LIST = ["ACF.dat", "AVF.dat", "BCF.dat"]
+
+
+class BaderCalculation(engine.CalcJob):
+    @classmethod
+    def define(cls, spec):
+        super().define(spec)
+        spec.input(
+            "parent_calc_folder",
+            valid_type=orm.RemoteData,
+            help="CP2K folder containing the charge-density cube.",
+        )
+        spec.input(
+            "charge_density_filename",
+            valid_type=orm.Str,
+            default=lambda: orm.Str(DEFAULT_CHARGE_DENSITY_FILENAME),
+            required=False,
+        )
+        spec.input(
+            "settings",
+            valid_type=orm.Dict,
+            default=lambda: orm.Dict(dict={}),
+            required=False,
+        )
+        spec.input("metadata.options.withmpi", valid_type=bool, default=False)
+
+    def prepare_for_submission(self, folder):
+        settings = self.inputs.settings.get_dict() if "settings" in self.inputs else {}
+
+        codeinfo = common.CodeInfo()
+        codeinfo.code_uuid = self.inputs.code.uuid
+        codeinfo.cmdline_params = [
+            "parent_calc_folder/" + self.inputs.charge_density_filename.value,
+        ]
+
+        calcinfo = common.CalcInfo()
+        calcinfo.uuid = self.uuid
+        calcinfo.codes_info = [codeinfo]
+        calcinfo.remote_symlink_list = []
+        calcinfo.remote_copy_list = []
+        calcinfo.local_copy_list = []
+        calcinfo.retrieve_list = settings.pop(
+            "additional_retrieve_list", DEFAULT_RETRIEVE_LIST
+        )
+
+        comp_uuid = self.inputs.parent_calc_folder.computer.uuid
+        remote_path = self.inputs.parent_calc_folder.get_remote_path()
+        copy_info = (comp_uuid, remote_path, "parent_calc_folder/")
+        if self.inputs.code.computer.uuid == comp_uuid:
+            calcinfo.remote_symlink_list.append(copy_info)
+        else:
+            calcinfo.remote_copy_list.append(copy_info)
+
+        if settings:
+            raise common.InputValidationError(
+                "The following keys have been found in settings but were not understood: "
+                + ",".join(settings.keys())
+            )
+
+        return calcinfo

--- a/aiida_nanotech_empa/plugins/sparse_overlap.py
+++ b/aiida_nanotech_empa/plugins/sparse_overlap.py
@@ -1,0 +1,79 @@
+from aiida import common, engine, orm
+
+
+DEFAULT_MATRIX_FILENAME = "aiida-overlap_matrix.out-1_0.Log"
+DEFAULT_OUTPUT_FILENAME = "sparse_overlap.npz"
+
+
+class SparseOverlapCalculation(engine.CalcJob):
+    @classmethod
+    def define(cls, spec):
+        super().define(spec)
+        spec.input(
+            "parent_calc_folder",
+            valid_type=orm.RemoteData,
+            help="CP2K folder with the AO overlap matrix log file.",
+        )
+        spec.input(
+            "threshold",
+            valid_type=orm.Float,
+            default=lambda: orm.Float(1.0e-10),
+            required=False,
+            help="Store matrix elements whose absolute value is larger than this threshold.",
+        )
+        spec.input(
+            "matrix_filename",
+            valid_type=orm.Str,
+            default=lambda: orm.Str(DEFAULT_MATRIX_FILENAME),
+            required=False,
+        )
+        spec.input(
+            "output_filename",
+            valid_type=orm.Str,
+            default=lambda: orm.Str(DEFAULT_OUTPUT_FILENAME),
+            required=False,
+        )
+        spec.input(
+            "settings",
+            valid_type=orm.Dict,
+            default=lambda: orm.Dict(dict={}),
+            required=False,
+        )
+        spec.input("metadata.options.withmpi", valid_type=bool, default=False)
+
+    def prepare_for_submission(self, folder):
+        settings = self.inputs.settings.get_dict() if "settings" in self.inputs else {}
+
+        output_filename = self.inputs.output_filename.value
+        codeinfo = common.CodeInfo()
+        codeinfo.code_uuid = self.inputs.code.uuid
+        codeinfo.cmdline_params = [
+            "parent_calc_folder/" + self.inputs.matrix_filename.value,
+            output_filename,
+            "--threshold",
+            str(self.inputs.threshold.value),
+        ]
+
+        calcinfo = common.CalcInfo()
+        calcinfo.uuid = self.uuid
+        calcinfo.codes_info = [codeinfo]
+        calcinfo.remote_symlink_list = []
+        calcinfo.remote_copy_list = []
+        calcinfo.local_copy_list = []
+        calcinfo.retrieve_list = settings.pop("additional_retrieve_list", [output_filename])
+
+        comp_uuid = self.inputs.parent_calc_folder.computer.uuid
+        remote_path = self.inputs.parent_calc_folder.get_remote_path()
+        copy_info = (comp_uuid, remote_path, "parent_calc_folder/")
+        if self.inputs.code.computer.uuid == comp_uuid:
+            calcinfo.remote_symlink_list.append(copy_info)
+        else:
+            calcinfo.remote_copy_list.append(copy_info)
+
+        if settings:
+            raise common.InputValidationError(
+                "The following keys have been found in settings but were not understood: "
+                + ",".join(settings.keys())
+            )
+
+        return calcinfo

--- a/aiida_nanotech_empa/version.py
+++ b/aiida_nanotech_empa/version.py
@@ -1,4 +1,4 @@
 #!/usr/bin/env python
 """This module contains project version information."""
 
-__version__ = "1.0.0b12"
+__version__ = "1.0.0b13"

--- a/aiida_nanotech_empa/workflows/cp2k/__init__.py
+++ b/aiida_nanotech_empa/workflows/cp2k/__init__.py
@@ -12,6 +12,7 @@ from .pdos_workchain import Cp2kPdosWorkChain
 from .phonons_workchain import Cp2kPhononsWorkChain
 from .reftraj_md_workchain import Cp2kRefTrajWorkChain
 from .replica_workchain import Cp2kReplicaWorkChain
+from .scf_workchain import Cp2kScfWorkChain
 from .stm_workchain import Cp2kStmWorkChain
 
 __all__ = (
@@ -26,6 +27,7 @@ __all__ = (
     "Cp2kAfmWorkChain",
     "Cp2kHrstmWorkChain",
     "Cp2kDiagWorkChain",
+    "Cp2kScfWorkChain",
     "Cp2kReplicaWorkChain",
     "Cp2kNebWorkChain",
     "Cp2kPhononsWorkChain",

--- a/aiida_nanotech_empa/workflows/cp2k/afm_workchain.py
+++ b/aiida_nanotech_empa/workflows/cp2k/afm_workchain.py
@@ -6,6 +6,7 @@ from aiida import engine, orm, plugins
 from ...utils import common_utils
 from . import cp2k_utils
 from .diag_workchain import Cp2kDiagWorkChain
+from .geo_opt_workchain import validate_on_unhandled_failure
 
 AfmCalculation = plugins.CalculationFactory("nanotech_empa.afm")
 
@@ -35,6 +36,35 @@ class Cp2kAfmWorkChain(engine.WorkChain):
             help="Define options for the cacluations: walltime, memory, CPUs, etc.",
         )
         spec.input("ppafm_params", valid_type=orm.Dict)
+        spec.input(
+            "max_iterations",
+            valid_type=orm.Int,
+            default=lambda: orm.Int(5),
+            required=False,
+            help="Maximum number of CP2K restart attempts delegated to cp2k.base.",
+        )
+        spec.input(
+            "clean_workdir",
+            valid_type=orm.Bool,
+            default=lambda: orm.Bool(False),
+            required=False,
+            help="Clean called CP2K calculation work directories after termination.",
+        )
+        spec.input(
+            "on_unhandled_failure",
+            valid_type=orm.Str,
+            default=lambda: orm.Str("pause"),
+            required=False,
+            validator=validate_on_unhandled_failure,
+            help="Action for unhandled cp2k.base failures: abort, pause, restart_once, or restart_and_pause.",
+        )
+        spec.input(
+            "pause_on_max_iterations",
+            valid_type=orm.Bool,
+            default=lambda: orm.Bool(True),
+            required=False,
+            help="Pause cp2k.base for inspection when restart max_iterations is reached.",
+        )
 
         spec.outline(
             cls.setup,
@@ -50,6 +80,12 @@ class Cp2kAfmWorkChain(engine.WorkChain):
             "ERROR_TERMINATION",
             message="One or more steps of the work chain failed.",
         )
+
+    def set_restart_policy(self, builder):
+        builder.max_iterations = self.inputs.max_iterations
+        builder.clean_workdir = self.inputs.clean_workdir
+        builder.on_unhandled_failure = self.inputs.on_unhandled_failure
+        builder.pause_on_max_iterations = self.inputs.pause_on_max_iterations
 
     def setup(self):
         self.report("Setting up workchain")
@@ -82,6 +118,7 @@ class Cp2kAfmWorkChain(engine.WorkChain):
         builder.protocol = self.inputs.protocol
         builder.dft_params = orm.Dict(self.ctx.dft_params)
         builder.options = orm.Dict(self.inputs.options)
+        self.set_restart_policy(builder)
 
         # Restart wfn.
         if "parent_calc_folder" in self.inputs:

--- a/aiida_nanotech_empa/workflows/cp2k/diag_workchain.py
+++ b/aiida_nanotech_empa/workflows/cp2k/diag_workchain.py
@@ -13,9 +13,7 @@ Cp2kBaseWorkChain = plugins.WorkflowFactory("cp2k.base")
 
 class Cp2kDiagWorkChain(engine.WorkChain):
     @classmethod
-    def define(cls, spec):
-        super().define(spec)
-
+    def define_common_inputs(cls, spec):
         spec.input("cp2k_code", valid_type=orm.Code)
         spec.input("structure", valid_type=orm.StructureData)
         spec.input("parent_calc_folder", valid_type=orm.RemoteData, required=False)
@@ -74,13 +72,9 @@ class Cp2kDiagWorkChain(engine.WorkChain):
             required=False,
             help="Pause cp2k.base for inspection when restart max_iterations is reached.",
         )
-        spec.outline(
-            cls.setup,
-            cls.run_ot_scf,
-            cls.run_diag_scf,
-            cls.finalize,
-        )
 
+    @classmethod
+    def define_common_outputs(cls, spec):
         spec.outputs.dynamic = True
 
         spec.exit_code(
@@ -88,6 +82,18 @@ class Cp2kDiagWorkChain(engine.WorkChain):
             "ERROR_TERMINATION",
             message="One or more steps of the work chain failed.",
         )
+
+    @classmethod
+    def define(cls, spec):
+        super().define(spec)
+        cls.define_common_inputs(spec)
+        spec.outline(
+            cls.setup,
+            cls.run_ot_scf,
+            cls.run_diag_scf,
+            cls.finalize,
+        )
+        cls.define_common_outputs(spec)
 
     def set_restart_policy(self, builder):
         builder.max_iterations = self.inputs.max_iterations
@@ -110,6 +116,10 @@ class Cp2kDiagWorkChain(engine.WorkChain):
         self.ctx.n_atoms = len(structure.sites)
 
         self.ctx.dft_params = self.inputs.dft_params.get_dict()
+        self.ctx.dft_params.setdefault("periodic", "XYZ")
+        self.ctx.dft_params.setdefault("uks", False)
+        self.ctx.dft_params.setdefault("elpa_switch", False)
+        self.ctx.dft_params.setdefault("sc_diag", False)
 
         # Resources.
         self.ctx.options = self.inputs.options.get_dict()
@@ -279,6 +289,8 @@ class Cp2kDiagWorkChain(engine.WorkChain):
             )
             input_dict["FORCE_EVAL"]["DFT"]["PRINT"]["MO_CUBES"]["STRIDE"] = "2 2 2"
 
+        self.update_diag_input_dict(input_dict)
+
         # Setup walltime.
         input_dict["GLOBAL"]["WALLTIME"] = max(
             600, self.ctx.options["max_wallclock_seconds"] - 600
@@ -319,3 +331,6 @@ class Cp2kDiagWorkChain(engine.WorkChain):
         self.out("remote_folder", self.ctx.diag_scf.outputs.remote_folder)
         self.out("retrieved", self.ctx.diag_scf.outputs.retrieved)
         self.report("Work chain is finished")
+
+    def update_diag_input_dict(self, input_dict):
+        """Hook for derived workchains to add diagonalization-only CP2K input."""

--- a/aiida_nanotech_empa/workflows/cp2k/diag_workchain.py
+++ b/aiida_nanotech_empa/workflows/cp2k/diag_workchain.py
@@ -6,6 +6,7 @@ from aiida import engine, orm, plugins
 
 from ...utils import common_utils
 from . import cp2k_utils
+from .geo_opt_workchain import validate_on_unhandled_failure
 
 Cp2kBaseWorkChain = plugins.WorkflowFactory("cp2k.base")
 
@@ -44,6 +45,35 @@ class Cp2kDiagWorkChain(engine.WorkChain):
             required=False,
             help="Define options for the cacluations: walltime, memory, CPUs, etc.",
         )
+        spec.input(
+            "max_iterations",
+            valid_type=orm.Int,
+            default=lambda: orm.Int(5),
+            required=False,
+            help="Maximum number of CP2K restart attempts delegated to cp2k.base.",
+        )
+        spec.input(
+            "clean_workdir",
+            valid_type=orm.Bool,
+            default=lambda: orm.Bool(False),
+            required=False,
+            help="Clean called CP2K calculation work directories after termination.",
+        )
+        spec.input(
+            "on_unhandled_failure",
+            valid_type=orm.Str,
+            default=lambda: orm.Str("pause"),
+            required=False,
+            validator=validate_on_unhandled_failure,
+            help="Action for unhandled cp2k.base failures: abort, pause, restart_once, or restart_and_pause.",
+        )
+        spec.input(
+            "pause_on_max_iterations",
+            valid_type=orm.Bool,
+            default=lambda: orm.Bool(True),
+            required=False,
+            help="Pause cp2k.base for inspection when restart max_iterations is reached.",
+        )
         spec.outline(
             cls.setup,
             cls.run_ot_scf,
@@ -58,6 +88,12 @@ class Cp2kDiagWorkChain(engine.WorkChain):
             "ERROR_TERMINATION",
             message="One or more steps of the work chain failed.",
         )
+
+    def set_restart_policy(self, builder):
+        builder.max_iterations = self.inputs.max_iterations
+        builder.clean_workdir = self.inputs.clean_workdir
+        builder.on_unhandled_failure = self.inputs.on_unhandled_failure
+        builder.pause_on_max_iterations = self.inputs.pause_on_max_iterations
 
     def setup(self):
         self.report("Setting up workchain")
@@ -121,6 +157,7 @@ class Cp2kDiagWorkChain(engine.WorkChain):
         # Set workflow inputs.
         builder = Cp2kBaseWorkChain.get_builder()
         builder.cp2k.code = self.inputs.cp2k_code
+        self.set_restart_policy(builder)
         builder.cp2k.structure = orm.StructureData(ase=self.ctx.structure_with_tags)
 
         builder.cp2k.file = self.ctx.files
@@ -249,6 +286,7 @@ class Cp2kDiagWorkChain(engine.WorkChain):
 
         builder = Cp2kBaseWorkChain.get_builder()
         builder.cp2k.code = self.inputs.cp2k_code
+        self.set_restart_policy(builder)
         builder.cp2k.structure = orm.StructureData(ase=self.ctx.structure_with_tags)
 
         builder.cp2k.file = self.ctx.files

--- a/aiida_nanotech_empa/workflows/cp2k/diag_workchain.py
+++ b/aiida_nanotech_empa/workflows/cp2k/diag_workchain.py
@@ -212,12 +212,17 @@ class Cp2kDiagWorkChain(engine.WorkChain):
         # Parser.
         builder.cp2k.metadata.options.parser_name = "cp2k_advanced_parser"
 
+        self.update_ot_input_dict(input_dict)
+
         # CP2K input dictionary.
         builder.cp2k.parameters = orm.Dict(input_dict)
         self.ctx.input_dict = copy.deepcopy(input_dict)
 
         future = self.submit(builder)
         self.to_context(ot_scf=future)
+
+    def update_ot_input_dict(self, input_dict):
+        pass
 
     def run_diag_scf(self):
         self.report("Running CP2K diagonalization SCF")

--- a/aiida_nanotech_empa/workflows/cp2k/fragment_separation.py
+++ b/aiida_nanotech_empa/workflows/cp2k/fragment_separation.py
@@ -4,6 +4,7 @@ from aiida import engine, orm, plugins
 
 from ...utils import common_utils, split_structure, string_utils
 from . import cp2k_utils
+from .geo_opt_workchain import validate_on_unhandled_failure
 
 StructureData = plugins.DataFactory("core.structure")
 Cp2kBaseWorkChain = plugins.WorkflowFactory("cp2k.base")
@@ -74,6 +75,35 @@ class Cp2kFragmentSeparationWorkChain(engine.WorkChain):
             required=False,
             help="Define options for the cacluations: walltime, memory, CPUs, etc.",
         )
+        spec.input(
+            "max_iterations",
+            valid_type=orm.Int,
+            default=lambda: orm.Int(5),
+            required=False,
+            help="Maximum number of CP2K restart attempts delegated to cp2k.base.",
+        )
+        spec.input(
+            "clean_workdir",
+            valid_type=orm.Bool,
+            default=lambda: orm.Bool(False),
+            required=False,
+            help="Clean called CP2K calculation work directories after termination.",
+        )
+        spec.input(
+            "on_unhandled_failure",
+            valid_type=orm.Str,
+            default=lambda: orm.Str("pause"),
+            required=False,
+            validator=validate_on_unhandled_failure,
+            help="Action for unhandled cp2k.base failures: abort, pause, restart_once, or restart_and_pause.",
+        )
+        spec.input(
+            "pause_on_max_iterations",
+            valid_type=orm.Bool,
+            default=lambda: orm.Bool(True),
+            required=False,
+            help="Pause cp2k.base for inspection when restart max_iterations is reached.",
+        )
 
         # in case wfn for the whole system is available and matches uks/rks parameters
         spec.input("parent_calc_folder", valid_type=orm.RemoteData, required=False)
@@ -101,6 +131,12 @@ class Cp2kFragmentSeparationWorkChain(engine.WorkChain):
 
     def should_run_cubehandler(self):
         return "cubehandler_code" in self.inputs
+
+    def set_restart_policy(self, builder):
+        builder.max_iterations = self.inputs.max_iterations
+        builder.clean_workdir = self.inputs.clean_workdir
+        builder.on_unhandled_failure = self.inputs.on_unhandled_failure
+        builder.pause_on_max_iterations = self.inputs.pause_on_max_iterations
 
     def setup(self):
         """Setup the work chain."""
@@ -158,6 +194,7 @@ class Cp2kFragmentSeparationWorkChain(engine.WorkChain):
             # Generic inputs that are always the same.
             builder = Cp2kBaseWorkChain.get_builder()
             builder.cp2k.code = self.inputs.code
+            self.set_restart_policy(builder)
             builder.cp2k.metadata.options.parser_name = "cp2k_advanced_parser"
 
             # restart wfn in case of fragment 'all'
@@ -241,6 +278,7 @@ class Cp2kFragmentSeparationWorkChain(engine.WorkChain):
             # Generic inputs that are always the same.
             builder = Cp2kBaseWorkChain.get_builder()
             builder.cp2k.code = self.inputs.code
+            self.set_restart_policy(builder)
             builder.cp2k.metadata.options = self.inputs.options[fragment]
             builder.cp2k.file = self.ctx.file
             builder.cp2k.metadata.options.parser_name = "cp2k_advanced_parser"

--- a/aiida_nanotech_empa/workflows/cp2k/geo_opt_workchain.py
+++ b/aiida_nanotech_empa/workflows/cp2k/geo_opt_workchain.py
@@ -9,6 +9,21 @@ from . import cp2k_utils
 Cp2kBaseWorkChain = plugins.WorkflowFactory("cp2k.base")
 CubeHandlerCalculation = plugins.CalculationFactory("nanotech_empa.cubehandler")
 
+ON_UNHANDLED_FAILURE_ACTIONS = ("abort", "pause", "restart_once", "restart_and_pause")
+
+
+def validate_on_unhandled_failure(value, _):
+    if value is None:
+        return None
+
+    if value.value not in ON_UNHANDLED_FAILURE_ACTIONS:
+        return (
+            f"on_unhandled_failure: {value.value!r}. Must be one of: "
+            f"{', '.join(ON_UNHANDLED_FAILURE_ACTIONS)}"
+        )
+
+    return None
+
 
 class Cp2kGeoOptWorkChain(engine.WorkChain):
     @classmethod
@@ -32,6 +47,35 @@ class Cp2kGeoOptWorkChain(engine.WorkChain):
             valid_type=dict,
             non_db=True,
             help="Define options for the cacluations: walltime, memory, CPUs, etc.",
+        )
+        spec.input(
+            "max_iterations",
+            valid_type=orm.Int,
+            default=lambda: orm.Int(5),
+            required=False,
+            help="Maximum number of CP2K restart attempts delegated to cp2k.base.",
+        )
+        spec.input(
+            "clean_workdir",
+            valid_type=orm.Bool,
+            default=lambda: orm.Bool(False),
+            required=False,
+            help="Clean called CP2K calculation work directories after termination.",
+        )
+        spec.input(
+            "on_unhandled_failure",
+            valid_type=orm.Str,
+            default=lambda: orm.Str("pause"),
+            required=False,
+            validator=validate_on_unhandled_failure,
+            help="Action for unhandled cp2k.base failures: abort, pause, restart_once, or restart_and_pause.",
+        )
+        spec.input(
+            "pause_on_max_iterations",
+            valid_type=orm.Bool,
+            default=lambda: orm.Bool(True),
+            required=False,
+            help="Pause cp2k.base for inspection when restart max_iterations is reached.",
         )
 
         # Workchain outline.
@@ -186,8 +230,16 @@ class Cp2kGeoOptWorkChain(engine.WorkChain):
         # Parser.
         builder.cp2k.metadata.options.parser_name = "cp2k_advanced_parser"
 
+        # Restart policy.
+        builder.max_iterations = self.inputs.max_iterations
+        builder.clean_workdir = self.inputs.clean_workdir
+        builder.on_unhandled_failure = self.inputs.on_unhandled_failure
+        builder.pause_on_max_iterations = self.inputs.pause_on_max_iterations
+
         # Handlers.
-        builder.handler_overrides = orm.Dict({"restart_incomplete_calculation": True})
+        builder.handler_overrides = orm.Dict(
+            {"restart_incomplete_calculation": {"enabled": True}}
+        )
 
         # Restart wfn.
         if "parent_calc_folder" in self.inputs:

--- a/aiida_nanotech_empa/workflows/cp2k/orbitals_workchain.py
+++ b/aiida_nanotech_empa/workflows/cp2k/orbitals_workchain.py
@@ -2,6 +2,7 @@ import numpy as np
 from aiida import engine, orm, plugins
 
 from ...utils import common_utils
+from .geo_opt_workchain import validate_on_unhandled_failure
 
 Cp2kDiagWorkChain = plugins.WorkflowFactory("nanotech_empa.cp2k.diag")
 StmCalculation = plugins.CalculationFactory("nanotech_empa.stm")
@@ -36,6 +37,35 @@ class Cp2kOrbitalsWorkChain(engine.WorkChain):
             non_db=True,
             help="Define options for the cacluations: walltime, memory, CPUs, etc.",
         )
+        spec.input(
+            "max_iterations",
+            valid_type=orm.Int,
+            default=lambda: orm.Int(5),
+            required=False,
+            help="Maximum number of CP2K restart attempts delegated to cp2k.base.",
+        )
+        spec.input(
+            "clean_workdir",
+            valid_type=orm.Bool,
+            default=lambda: orm.Bool(False),
+            required=False,
+            help="Clean called CP2K calculation work directories after termination.",
+        )
+        spec.input(
+            "on_unhandled_failure",
+            valid_type=orm.Str,
+            default=lambda: orm.Str("pause"),
+            required=False,
+            validator=validate_on_unhandled_failure,
+            help="Action for unhandled cp2k.base failures: abort, pause, restart_once, or restart_and_pause.",
+        )
+        spec.input(
+            "pause_on_max_iterations",
+            valid_type=orm.Bool,
+            default=lambda: orm.Bool(True),
+            required=False,
+            help="Pause cp2k.base for inspection when restart max_iterations is reached.",
+        )
 
         spec.outline(
             cls.setup,
@@ -55,6 +85,12 @@ class Cp2kOrbitalsWorkChain(engine.WorkChain):
             message="One or more steps of the work chain failed.",
         )
 
+    def set_restart_policy(self, builder):
+        builder.max_iterations = self.inputs.max_iterations
+        builder.clean_workdir = self.inputs.clean_workdir
+        builder.on_unhandled_failure = self.inputs.on_unhandled_failure
+        builder.pause_on_max_iterations = self.inputs.pause_on_max_iterations
+
     def setup(self):
         self.report("Setting up workchain")
         n_lumo = int(self.inputs.spm_params.get_dict()["--n_lumo"])
@@ -66,6 +102,7 @@ class Cp2kOrbitalsWorkChain(engine.WorkChain):
         self.report("Running CP2K diagonalization SCF")
         builder = Cp2kDiagWorkChain.get_builder()
         builder.cp2k_code = self.inputs.cp2k_code
+        self.set_restart_policy(builder)
         builder.structure = self.inputs.structure
         builder.dft_params = orm.Dict(self.ctx.dft_params)
         builder.protocol = self.inputs.protocol

--- a/aiida_nanotech_empa/workflows/cp2k/pdos_workchain.py
+++ b/aiida_nanotech_empa/workflows/cp2k/pdos_workchain.py
@@ -5,6 +5,7 @@ from aiida import engine, orm, plugins
 
 from ...utils import common_utils, split_structure
 from . import cp2k_utils
+from .geo_opt_workchain import validate_on_unhandled_failure
 
 Cp2kDiagWorkChain = plugins.WorkflowFactory("nanotech_empa.cp2k.diag")
 OverlapCalculation = plugins.CalculationFactory("nanotech_empa.overlap")
@@ -51,6 +52,35 @@ class Cp2kPdosWorkChain(engine.WorkChain):
             non_db=True,
             help="Define options for the cacluations: walltime, memory, CPUs, etc.",
         )
+        spec.input(
+            "max_iterations",
+            valid_type=orm.Int,
+            default=lambda: orm.Int(5),
+            required=False,
+            help="Maximum number of CP2K restart attempts delegated to cp2k.base.",
+        )
+        spec.input(
+            "clean_workdir",
+            valid_type=orm.Bool,
+            default=lambda: orm.Bool(False),
+            required=False,
+            help="Clean called CP2K calculation work directories after termination.",
+        )
+        spec.input(
+            "on_unhandled_failure",
+            valid_type=orm.Str,
+            default=lambda: orm.Str("pause"),
+            required=False,
+            validator=validate_on_unhandled_failure,
+            help="Action for unhandled cp2k.base failures: abort, pause, restart_once, or restart_and_pause.",
+        )
+        spec.input(
+            "pause_on_max_iterations",
+            valid_type=orm.Bool,
+            default=lambda: orm.Bool(True),
+            required=False,
+            help="Pause cp2k.base for inspection when restart max_iterations is reached.",
+        )
 
         spec.outline(
             cls.setup,
@@ -68,6 +98,12 @@ class Cp2kPdosWorkChain(engine.WorkChain):
             "ERROR_TERMINATION",
             message="One or more steps of the work chain failed.",
         )
+
+    def set_restart_policy(self, builder):
+        builder.max_iterations = self.inputs.max_iterations
+        builder.clean_workdir = self.inputs.clean_workdir
+        builder.on_unhandled_failure = self.inputs.on_unhandled_failure
+        builder.pause_on_max_iterations = self.inputs.pause_on_max_iterations
 
     def setup(self):
         self.report("Setting up workchain")
@@ -127,6 +163,7 @@ class Cp2kPdosWorkChain(engine.WorkChain):
         self.report("Running Diag Workchain for the full system.")
         builder = Cp2kDiagWorkChain.get_builder()
         builder.cp2k_code = self.inputs.cp2k_code
+        self.set_restart_policy(builder)
         builder.structure = self.ctx.structure
         builder.protocol = self.inputs.protocol
         builder.dft_params = orm.Dict(self.ctx.dft_parameters)
@@ -148,6 +185,7 @@ class Cp2kPdosWorkChain(engine.WorkChain):
             self.report("Running Diag Workchain for the fragment.")
             builder = Cp2kDiagWorkChain.get_builder()
             builder.cp2k_code = self.inputs.cp2k_code
+            self.set_restart_policy(builder)
             builder.structure = self.ctx.molecule_structure
             builder.protocol = self.inputs.protocol
             builder.dft_params = orm.Dict(self.ctx.mol_dft_parameters)

--- a/aiida_nanotech_empa/workflows/cp2k/phonons_workchain.py
+++ b/aiida_nanotech_empa/workflows/cp2k/phonons_workchain.py
@@ -4,6 +4,7 @@ from aiida import engine, orm, plugins
 
 from ...utils import common_utils
 from . import cp2k_utils
+from .geo_opt_workchain import validate_on_unhandled_failure
 
 Cp2kGeoOptWorkChain = plugins.WorkflowFactory("nanotech_empa.cp2k.geo_opt")
 Cp2kCalculation = plugins.CalculationFactory("cp2k")
@@ -32,6 +33,35 @@ class Cp2kPhononsWorkChain(engine.WorkChain):
             non_db=True,
             help="Define options for the cacluations: walltime, memory, CPUs, etc.",
         )
+        spec.input(
+            "max_iterations",
+            valid_type=orm.Int,
+            default=lambda: orm.Int(5),
+            required=False,
+            help="Maximum number of CP2K restart attempts delegated to cp2k.base.",
+        )
+        spec.input(
+            "clean_workdir",
+            valid_type=orm.Bool,
+            default=lambda: orm.Bool(False),
+            required=False,
+            help="Clean called CP2K calculation work directories after termination.",
+        )
+        spec.input(
+            "on_unhandled_failure",
+            valid_type=orm.Str,
+            default=lambda: orm.Str("pause"),
+            required=False,
+            validator=validate_on_unhandled_failure,
+            help="Action for unhandled cp2k.base failures: abort, pause, restart_once, or restart_and_pause.",
+        )
+        spec.input(
+            "pause_on_max_iterations",
+            valid_type=orm.Bool,
+            default=lambda: orm.Bool(True),
+            required=False,
+            help="Pause cp2k.base for inspection when restart max_iterations is reached.",
+        )
 
         spec.outline(
             cls.setup,
@@ -46,6 +76,12 @@ class Cp2kPhononsWorkChain(engine.WorkChain):
             "ERROR_TERMINATION",
             message="One or more steps of the work chain failed.",
         )
+
+    def set_restart_policy(self, builder):
+        builder.max_iterations = self.inputs.max_iterations
+        builder.clean_workdir = self.inputs.clean_workdir
+        builder.on_unhandled_failure = self.inputs.on_unhandled_failure
+        builder.pause_on_max_iterations = self.inputs.pause_on_max_iterations
 
     def setup(self):
         self.report("Inspecting input and setting up things")
@@ -108,6 +144,7 @@ class Cp2kPhononsWorkChain(engine.WorkChain):
 
         builder.code = self.inputs.code
         builder.structure = self.inputs.structure
+        self.set_restart_policy(builder)
 
         # Restart WFN.
         if "parent_calc_folder" in self.inputs:

--- a/aiida_nanotech_empa/workflows/cp2k/replica_workchain.py
+++ b/aiida_nanotech_empa/workflows/cp2k/replica_workchain.py
@@ -5,6 +5,7 @@ from aiida import engine, orm, plugins
 
 from ...utils import common_utils
 from . import cp2k_utils
+from .geo_opt_workchain import validate_on_unhandled_failure
 
 Cp2kBaseWorkChain = plugins.WorkflowFactory("cp2k.base")
 Cp2kCalculation = plugins.CalculationFactory("cp2k")
@@ -38,6 +39,35 @@ class Cp2kReplicaWorkChain(engine.WorkChain):
             non_db=True,
             help="Define options for the cacluations: walltime, memory, CPUs, etc.",
         )
+        spec.input(
+            "max_iterations",
+            valid_type=orm.Int,
+            default=lambda: orm.Int(5),
+            required=False,
+            help="Maximum number of CP2K restart attempts delegated to cp2k.base.",
+        )
+        spec.input(
+            "clean_workdir",
+            valid_type=orm.Bool,
+            default=lambda: orm.Bool(False),
+            required=False,
+            help="Clean called CP2K calculation work directories after termination.",
+        )
+        spec.input(
+            "on_unhandled_failure",
+            valid_type=orm.Str,
+            default=lambda: orm.Str("pause"),
+            required=False,
+            validator=validate_on_unhandled_failure,
+            help="Action for unhandled cp2k.base failures: abort, pause, restart_once, or restart_and_pause.",
+        )
+        spec.input(
+            "pause_on_max_iterations",
+            valid_type=orm.Bool,
+            default=lambda: orm.Bool(True),
+            required=False,
+            help="Pause cp2k.base for inspection when restart max_iterations is reached.",
+        )
 
         spec.outline(
             cls.setup,
@@ -61,6 +91,12 @@ class Cp2kReplicaWorkChain(engine.WorkChain):
         spec.output_namespace("structures", valid_type=orm.StructureData)
         spec.output_namespace("details", valid_type=orm.Dict)
         spec.exit_code(390, "ERROR_TERMINATION", message="One geo opt failed")
+
+    def set_restart_policy(self, builder):
+        builder.max_iterations = self.inputs.max_iterations
+        builder.clean_workdir = self.inputs.clean_workdir
+        builder.on_unhandled_failure = self.inputs.on_unhandled_failure
+        builder.pause_on_max_iterations = self.inputs.pause_on_max_iterations
 
     def setup(self):
         """Initialize the workchain process."""
@@ -234,13 +270,14 @@ class Cp2kReplicaWorkChain(engine.WorkChain):
                 structure = self.ctx.lowest_energy_structure
 
                 files, input_dict, structure_with_tags = cp2k_utils.get_dft_inputs(
-                    self.inputs.dft_params,
+                    self.inputs.dft_params.get_dict(),
                     structure,
                     "geo_opt_protocol.yml",
                     self.inputs.protocol.value,
                 )
 
                 builder = Cp2kBaseWorkChain.get_builder()
+                self.set_restart_policy(builder)
                 builder.cp2k.code = self.inputs.code
                 builder.cp2k.structure = orm.StructureData(ase=structure_with_tags)
                 builder.cp2k.file = files

--- a/aiida_nanotech_empa/workflows/cp2k/scf_workchain.py
+++ b/aiida_nanotech_empa/workflows/cp2k/scf_workchain.py
@@ -3,6 +3,7 @@ from aiida import engine, orm, plugins
 from ...utils import common_utils
 from .diag_workchain import Cp2kDiagWorkChain
 
+BaderCalculation = plugins.CalculationFactory("nanotech_empa.bader")
 SparseOverlapCalculation = plugins.CalculationFactory("nanotech_empa.sparse_overlap")
 
 
@@ -44,6 +45,26 @@ class Cp2kScfWorkChain(Cp2kDiagWorkChain):
             required=False,
             help="Absolute-value threshold for retrieved sparse overlap entries.",
         )
+        spec.input(
+            "compute_bader_charges",
+            valid_type=orm.Bool,
+            default=lambda: orm.Bool(False),
+            required=False,
+            help="Run Bader charge analysis on the OT charge-density cube.",
+        )
+        spec.input(
+            "bader_code",
+            valid_type=orm.Code,
+            required=False,
+            help="Bader executable configured for the nanotech_empa.bader plugin.",
+        )
+        spec.input(
+            "bader_cutoff",
+            valid_type=orm.Float,
+            default=lambda: orm.Float(1200.0),
+            required=False,
+            help="Plane-wave cutoff used for the OT charge-density cube for Bader analysis.",
+        )
         spec.outline(
             cls.setup,
             cls.run_ot_scf,
@@ -53,6 +74,9 @@ class Cp2kScfWorkChain(Cp2kDiagWorkChain):
                     cls.run_sparse_overlap,
                 ),
             ),
+            engine.if_(cls.should_run_bader)(
+                cls.run_bader,
+            ),
             cls.finalize,
         )
         spec.exit_code(
@@ -60,8 +84,16 @@ class Cp2kScfWorkChain(Cp2kDiagWorkChain):
             "ERROR_MISSING_SPARSE_OVERLAP_CODE",
             message="A sparse overlap code is required to retrieve sparse overlap entries.",
         )
+        spec.exit_code(
+            392,
+            "ERROR_MISSING_BADER_CODE",
+            message="A Bader code is required to compute Bader charges.",
+        )
 
     def should_run_diag_scf(self):
+        if self.should_run_bader():
+            return False
+
         dft_params = self.inputs.dft_params.get_dict()
         return (
             self.inputs.write_overlap_matrix.value
@@ -69,8 +101,24 @@ class Cp2kScfWorkChain(Cp2kDiagWorkChain):
             or dft_params.get("added_mos", 0) > 0
         )
 
+    def should_run_bader(self):
+        return self.inputs.compute_bader_charges.value
+
     def should_run_sparse_overlap(self):
         return self.inputs.retrieve_sparse_overlap.value
+
+    def update_ot_input_dict(self, input_dict):
+        if not self.should_run_bader():
+            return
+
+        input_dict["FORCE_EVAL"]["DFT"]["MGRID"]["CUTOFF"] = (
+            self.inputs.bader_cutoff.value
+        )
+        print_section = input_dict["FORCE_EVAL"]["DFT"].setdefault("PRINT", {})
+        charge_density = print_section.setdefault("E_DENSITY_CUBE", {})
+        charge_density["STRIDE"] = "1 1 1"
+        charge_density.setdefault("EACH", {"QS_SCF": "0", "GEO_OPT": "0"})
+        charge_density.setdefault("ADD_LAST", "NUMERIC")
 
     def update_diag_input_dict(self, input_dict):
         if not (
@@ -114,7 +162,52 @@ class Cp2kScfWorkChain(Cp2kDiagWorkChain):
         }
         return engine.ToContext(sparse_overlap=self.submit(builder))
 
+    def run_bader(self):
+        if "bader_code" not in self.inputs:
+            return self.exit_codes.ERROR_MISSING_BADER_CODE
+
+        if not common_utils.check_if_calc_ok(self, self.ctx.ot_scf):
+            self.report("OT SCF failed")
+            return self.exit_codes.ERROR_TERMINATION
+
+        self.report("Running Bader charge analysis")
+        builder = BaderCalculation.get_builder()
+        builder.code = self.inputs.bader_code
+        builder.parent_calc_folder = self.ctx.ot_scf.outputs.remote_folder
+        builder.charge_density_filename = orm.Str("aiida-ELECTRON_DENSITY-1_0.cube")
+        builder.metadata = {
+            "label": "bader",
+            "options": {
+                "resources": {
+                    "num_machines": 1,
+                    "num_mpiprocs_per_machine": 1,
+                    "num_cores_per_mpiproc": 1,
+                },
+                "max_wallclock_seconds": min(
+                    3600, self.ctx.options["max_wallclock_seconds"]
+                ),
+                "withmpi": False,
+            },
+        }
+        return engine.ToContext(bader=self.submit(builder))
+
     def finalize(self):
+        if self.should_run_bader():
+            if not common_utils.check_if_calc_ok(self, self.ctx.ot_scf):
+                self.report("OT SCF failed")
+                return self.exit_codes.ERROR_TERMINATION
+
+            if not common_utils.check_if_calc_ok(self, self.ctx.bader):
+                self.report("Bader charge analysis failed")
+                return self.exit_codes.ERROR_TERMINATION
+
+            self.out("output_parameters", self.ctx.ot_scf.outputs.output_parameters)
+            self.out("remote_folder", self.ctx.ot_scf.outputs.remote_folder)
+            self.out("retrieved", self.ctx.ot_scf.outputs.retrieved)
+            self.out("bader_retrieved", self.ctx.bader.outputs.retrieved)
+            self.report("Work chain is finished")
+            return None
+
         if self.should_run_diag_scf():
             if not common_utils.check_if_calc_ok(self, self.ctx.diag_scf):
                 self.report("diagonalization scf failed")

--- a/aiida_nanotech_empa/workflows/cp2k/scf_workchain.py
+++ b/aiida_nanotech_empa/workflows/cp2k/scf_workchain.py
@@ -1,0 +1,146 @@
+from aiida import engine, orm, plugins
+
+from ...utils import common_utils
+from .diag_workchain import Cp2kDiagWorkChain
+
+SparseOverlapCalculation = plugins.CalculationFactory("nanotech_empa.sparse_overlap")
+
+
+class Cp2kScfWorkChain(Cp2kDiagWorkChain):
+    @classmethod
+    def define(cls, spec):
+        super().define(spec)
+        spec.input(
+            "write_overlap_matrix",
+            valid_type=orm.Bool,
+            default=lambda: orm.Bool(False),
+            required=False,
+            help="Run the diagonalization SCF step and print the AO overlap matrix.",
+        )
+        spec.input(
+            "retrieve_sparse_overlap",
+            valid_type=orm.Bool,
+            default=lambda: orm.Bool(False),
+            required=False,
+            help="Post-process the remote AO overlap matrix and retrieve sparse entries.",
+        )
+        spec.input(
+            "sparse_overlap_code",
+            valid_type=orm.Code,
+            required=False,
+            help="Python code configured for the nanotech_empa.sparse_overlap plugin.",
+        )
+        spec.input(
+            "overlap_ndigits",
+            valid_type=orm.Int,
+            default=lambda: orm.Int(14),
+            required=False,
+            help="Number of digits for the printed AO overlap matrix.",
+        )
+        spec.input(
+            "overlap_threshold",
+            valid_type=orm.Float,
+            default=lambda: orm.Float(1.0e-10),
+            required=False,
+            help="Absolute-value threshold for retrieved sparse overlap entries.",
+        )
+        spec.outline(
+            cls.setup,
+            cls.run_ot_scf,
+            engine.if_(cls.should_run_diag_scf)(
+                cls.run_diag_scf,
+                engine.if_(cls.should_run_sparse_overlap)(
+                    cls.run_sparse_overlap,
+                ),
+            ),
+            cls.finalize,
+        )
+        spec.exit_code(
+            391,
+            "ERROR_MISSING_SPARSE_OVERLAP_CODE",
+            message="A sparse overlap code is required to retrieve sparse overlap entries.",
+        )
+
+    def should_run_diag_scf(self):
+        dft_params = self.inputs.dft_params.get_dict()
+        return (
+            self.inputs.write_overlap_matrix.value
+            or self.inputs.retrieve_sparse_overlap.value
+            or dft_params.get("added_mos", 0) > 0
+        )
+
+    def should_run_sparse_overlap(self):
+        return self.inputs.retrieve_sparse_overlap.value
+
+    def update_diag_input_dict(self, input_dict):
+        if not (
+            self.inputs.write_overlap_matrix.value
+            or self.inputs.retrieve_sparse_overlap.value
+        ):
+            return
+
+        print_section = input_dict["FORCE_EVAL"]["DFT"].setdefault("PRINT", {})
+        print_section["AO_MATRICES"] = {
+            "_": "ON",
+            "OVERLAP": "T",
+            "FILENAME": "overlap_matrix.out",
+            "NDIGITS": self.inputs.overlap_ndigits.value,
+        }
+
+    def run_sparse_overlap(self):
+        if "sparse_overlap_code" not in self.inputs:
+            return self.exit_codes.ERROR_MISSING_SPARSE_OVERLAP_CODE
+
+        self.report("Running sparse overlap post-processing")
+        builder = SparseOverlapCalculation.get_builder()
+        builder.code = self.inputs.sparse_overlap_code
+        builder.parent_calc_folder = self.ctx.diag_scf.outputs.remote_folder
+        builder.threshold = self.inputs.overlap_threshold
+        builder.matrix_filename = orm.Str("aiida-overlap_matrix.out-1_0.Log")
+        builder.output_filename = orm.Str("sparse_overlap.npz")
+        builder.metadata = {
+            "label": "sparse_overlap",
+            "options": {
+                "resources": {
+                    "num_machines": 1,
+                    "num_mpiprocs_per_machine": 1,
+                    "num_cores_per_mpiproc": 1,
+                },
+                "max_wallclock_seconds": min(
+                    3600, self.ctx.options["max_wallclock_seconds"]
+                ),
+                "withmpi": False,
+            },
+        }
+        return engine.ToContext(sparse_overlap=self.submit(builder))
+
+    def finalize(self):
+        if self.should_run_diag_scf():
+            if not common_utils.check_if_calc_ok(self, self.ctx.diag_scf):
+                self.report("diagonalization scf failed")
+                return self.exit_codes.ERROR_TERMINATION
+
+            if self.should_run_sparse_overlap():
+                if not common_utils.check_if_calc_ok(self, self.ctx.sparse_overlap):
+                    self.report("sparse overlap post-processing failed")
+                    return self.exit_codes.ERROR_TERMINATION
+                self.out(
+                    "sparse_overlap_retrieved",
+                    self.ctx.sparse_overlap.outputs.retrieved,
+                )
+
+            self.out("output_parameters", self.ctx.diag_scf.outputs.output_parameters)
+            self.out("remote_folder", self.ctx.diag_scf.outputs.remote_folder)
+            self.out("retrieved", self.ctx.diag_scf.outputs.retrieved)
+            self.report("Work chain is finished")
+            return None
+
+        if not common_utils.check_if_calc_ok(self, self.ctx.ot_scf):
+            self.report("OT SCF failed")
+            return self.exit_codes.ERROR_TERMINATION
+
+        self.out("output_parameters", self.ctx.ot_scf.outputs.output_parameters)
+        self.out("remote_folder", self.ctx.ot_scf.outputs.remote_folder)
+        self.out("retrieved", self.ctx.ot_scf.outputs.retrieved)
+        self.report("Work chain is finished")
+        return None

--- a/aiida_nanotech_empa/workflows/cp2k/stm_workchain.py
+++ b/aiida_nanotech_empa/workflows/cp2k/stm_workchain.py
@@ -2,6 +2,7 @@ import numpy as np
 from aiida import engine, orm, plugins
 
 from ...utils import common_utils
+from .geo_opt_workchain import validate_on_unhandled_failure
 
 Cp2kDiagWorkChain = plugins.WorkflowFactory("nanotech_empa.cp2k.diag")
 StmCalculation = plugins.CalculationFactory("nanotech_empa.stm")
@@ -31,6 +32,35 @@ class Cp2kStmWorkChain(engine.WorkChain):
             non_db=True,
             help="Define options for the cacluations: walltime, memory, CPUs, etc.",
         )
+        spec.input(
+            "max_iterations",
+            valid_type=orm.Int,
+            default=lambda: orm.Int(5),
+            required=False,
+            help="Maximum number of CP2K restart attempts delegated to cp2k.base.",
+        )
+        spec.input(
+            "clean_workdir",
+            valid_type=orm.Bool,
+            default=lambda: orm.Bool(False),
+            required=False,
+            help="Clean called CP2K calculation work directories after termination.",
+        )
+        spec.input(
+            "on_unhandled_failure",
+            valid_type=orm.Str,
+            default=lambda: orm.Str("pause"),
+            required=False,
+            validator=validate_on_unhandled_failure,
+            help="Action for unhandled cp2k.base failures: abort, pause, restart_once, or restart_and_pause.",
+        )
+        spec.input(
+            "pause_on_max_iterations",
+            valid_type=orm.Bool,
+            default=lambda: orm.Bool(True),
+            required=False,
+            help="Pause cp2k.base for inspection when restart max_iterations is reached.",
+        )
 
         spec.outline(
             cls.setup,
@@ -46,6 +76,12 @@ class Cp2kStmWorkChain(engine.WorkChain):
             "ERROR_TERMINATION",
             message="One or more steps of the work chain failed.",
         )
+
+    def set_restart_policy(self, builder):
+        builder.max_iterations = self.inputs.max_iterations
+        builder.clean_workdir = self.inputs.clean_workdir
+        builder.on_unhandled_failure = self.inputs.on_unhandled_failure
+        builder.pause_on_max_iterations = self.inputs.pause_on_max_iterations
 
     def setup(self):
         self.report("Setting up workchain")
@@ -64,6 +100,7 @@ class Cp2kStmWorkChain(engine.WorkChain):
         builder.protocol = self.inputs.protocol
         builder.dft_params = orm.Dict(self.ctx.dft_params)
         builder.options = orm.Dict(self.inputs.options)
+        self.set_restart_policy(builder)
 
         # Restart wfn, if requested.
         if "parent_calc_folder" in self.inputs:

--- a/aiida_nanotech_empa/workflows/qe/nanoribbon.py
+++ b/aiida_nanotech_empa/workflows/qe/nanoribbon.py
@@ -37,9 +37,9 @@ class NanoribbonWorkChain(engine.WorkChain):
             default=lambda: orm.Int(3600),
             required=False,
         )
-        spec.input("pw_code", valid_type=orm.Code)
-        spec.input("pp_code", valid_type=orm.Code)
-        spec.input("projwfc_code", valid_type=orm.Code)
+        spec.input("pw_code", valid_type=orm.AbstractCode)
+        spec.input("pp_code", valid_type=orm.AbstractCode)
+        spec.input("projwfc_code", valid_type=orm.AbstractCode)
         spec.input("structure", valid_type=orm.StructureData)
         spec.input(
             "tot_charge",
@@ -219,7 +219,7 @@ class NanoribbonWorkChain(engine.WorkChain):
             "resources": {
                 "num_machines": int(nnodes),
                 "num_mpiprocs_per_machine": self.ctx.nproc_mach,
-                "num_cores_per_mpiproc":1,
+                "num_cores_per_mpiproc": 1,
             },
             "max_wallclock_seconds": 1800,  # 30 minutes
             "withmpi": True,
@@ -293,7 +293,7 @@ class NanoribbonWorkChain(engine.WorkChain):
             "resources": {
                 "num_machines": int(nnodes),
                 "num_mpiprocs_per_machine": nproc_mach,
-                "num_cores_per_mpiproc":1,
+                "num_cores_per_mpiproc": 1,
             },
             "max_wallclock_seconds": self.inputs.wall_seconds.value,  # default 1 hour, max 24 hours
             "withmpi": True,
@@ -373,7 +373,7 @@ class NanoribbonWorkChain(engine.WorkChain):
             "resources": {
                 "num_machines": int(nnodes),
                 "num_mpiprocs_per_machine": self.ctx.nproc_mach,
-                "num_cores_per_mpiproc":1,
+                "num_cores_per_mpiproc": 1,
             },
             "max_wallclock_seconds": int(
                 self.inputs.wall_seconds.value / 24 * nhours
@@ -478,7 +478,7 @@ class NanoribbonWorkChain(engine.WorkChain):
             "resources": {
                 "num_machines": int(nnodes),
                 "num_mpiprocs_per_machine": self.ctx.nproc_mach,
-                "num_cores_per_mpiproc":1,
+                "num_cores_per_mpiproc": 1,
             },
             "max_wallclock_seconds": 30 * 60,  # 30 minutes
             "withmpi": True,
@@ -562,7 +562,7 @@ class NanoribbonWorkChain(engine.WorkChain):
 
         natoms = len(structure.sites)
         max_npools = spinpools * min(1 + int(nkpoints / 4), int(6))
-        max_npools = min(self.ctx.nproc_mach, max_npools) #added for daint.alps
+        max_npools = min(self.ctx.nproc_mach, max_npools)  # added for daint.alps
         nnodes_base = min(max_nodes, (1 + int(natoms / mem_node)))
 
         guess_nnodes = max_npools * nnodes_base
@@ -587,7 +587,7 @@ class NanoribbonWorkChain(engine.WorkChain):
             "resources": {
                 "num_machines": int(nnodes),
                 "num_mpiprocs_per_machine": self.ctx.nproc_mach,
-                "num_cores_per_mpiproc":1,
+                "num_cores_per_mpiproc": 1,
             },
             "withmpi": True,
             "max_wallclock_seconds": wallseconds,

--- a/examples/workflows/example_nanoribbon.py
+++ b/examples/workflows/example_nanoribbon.py
@@ -39,8 +39,8 @@ def _example_nanoribbon(
     builder.structure = orm.StructureData(ase=ase.io.read(geo_file))
     # builder.pseudo_family = orm.Str("SSSP_modified")
     builder.pseudo_family = orm.Str(
-        "SSSP/1.2/PBE/efficiency"
-    )  # It requires aiida-pseudo install sssp!
+        "SSSP/1.3/PBE/precision"
+    )  # It requires: aiida-pseudo install sssp --functional PBE --version 1.3 -p precision
 
     # Metadata
     builder.metadata = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ dev = [
 "nanotech_empa.stm" = "aiida_nanotech_empa.plugins:StmCalculation"
 "nanotech_empa.overlap" = "aiida_nanotech_empa.plugins:OverlapCalculation"
 "nanotech_empa.sparse_overlap" = "aiida_nanotech_empa.plugins:SparseOverlapCalculation"
+"nanotech_empa.bader" = "aiida_nanotech_empa.plugins:BaderCalculation"
 "nanotech_empa.afm" = "aiida_nanotech_empa.plugins:AfmCalculation"
 "nanotech_empa.hrstm" = "aiida_nanotech_empa.plugins:HrstmCalculation"
 "nanotech_empa.cubehandler" = "aiida_nanotech_empa.plugins:CubeHandlerCalculation"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ dev = [
 [project.entry-points."aiida.calculations"]
 "nanotech_empa.stm" = "aiida_nanotech_empa.plugins:StmCalculation"
 "nanotech_empa.overlap" = "aiida_nanotech_empa.plugins:OverlapCalculation"
+"nanotech_empa.sparse_overlap" = "aiida_nanotech_empa.plugins:SparseOverlapCalculation"
 "nanotech_empa.afm" = "aiida_nanotech_empa.plugins:AfmCalculation"
 "nanotech_empa.hrstm" = "aiida_nanotech_empa.plugins:HrstmCalculation"
 "nanotech_empa.cubehandler" = "aiida_nanotech_empa.plugins:CubeHandlerCalculation"
@@ -84,6 +85,7 @@ dev = [
 "nanotech_empa.cp2k.afm" = "aiida_nanotech_empa.workflows.cp2k:Cp2kAfmWorkChain"
 "nanotech_empa.cp2k.hrstm" = "aiida_nanotech_empa.workflows.cp2k:Cp2kHrstmWorkChain"
 "nanotech_empa.cp2k.diag" = "aiida_nanotech_empa.workflows.cp2k:Cp2kDiagWorkChain"
+"nanotech_empa.cp2k.scf" = "aiida_nanotech_empa.workflows.cp2k:Cp2kScfWorkChain"
 "nanotech_empa.cp2k.replica" = "aiida_nanotech_empa.workflows.cp2k:Cp2kReplicaWorkChain"
 "nanotech_empa.cp2k.neb" = "aiida_nanotech_empa.workflows.cp2k:Cp2kNebWorkChain"
 "nanotech_empa.cp2k.phonons" = "aiida_nanotech_empa.workflows.cp2k:Cp2kPhononsWorkChain"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    "aiida-core>=2.6,<2.8",
+    "aiida-core>=2.8,<3.0.0",
     "aiida-quantumespresso~=4.8",
     "aiida-pseudo~=1.7",
     "aiida-cp2k>=2.1.1,<3.0.0",
@@ -94,7 +94,7 @@ dev = [
 slurm_ethz_euler = "aiida_nanotech_empa.schedulers:ETHZEulerSlurmScheduler"
 
 [tool.bumpver]
-current_version = "v1.0.0b12"
+current_version = "v1.0.0b13"
 version_pattern = "vMAJOR.MINOR.PATCH[PYTAGNUM]"
 commit_message = "Bump version {old_version} -> {new_version}."
 commit = true


### PR DESCRIPTION
Part of the aiida-nanotech-empa split-PR chain extracted from the full working reference branch feature/cp2k-dft-protocol-refactor. This PR depends on #196 (PR-A1).

Scope:
- add BaderCalculation CalcJob and entry point;
- add optional Bader branch to Cp2kScfWorkChain;
- request fine charge-density output from the OT step when Bader is enabled;
- propagate Bader outputs without changing the default SCF overlap behavior.

Files touched:
- aiida_nanotech_empa/plugins/__init__.py
- aiida_nanotech_empa/plugins/bader.py
- aiida_nanotech_empa/workflows/cp2k/diag_workchain.py
- aiida_nanotech_empa/workflows/cp2k/scf_workchain.py
- pyproject.toml

Validation:
- python -m py_compile on bader.py and scf_workchain.py
- compared file list/stat against commit 3904bec from the full reference history.