### PR TITLE
PR-A3: Expose SCF outputs for surfaces search

### DIFF
--- a/aiida_nanotech_empa/workflows/cp2k/scf_workchain.py
+++ b/aiida_nanotech_empa/workflows/cp2k/scf_workchain.py
@@ -204,7 +204,9 @@ class Cp2kScfWorkChain(Cp2kDiagWorkChain):
             self.out("output_parameters", self.ctx.ot_scf.outputs.output_parameters)
             self.out("remote_folder", self.ctx.ot_scf.outputs.remote_folder)
             self.out("retrieved", self.ctx.ot_scf.outputs.retrieved)
+            self.out("ot_retrieved", self.ctx.ot_scf.outputs.retrieved)
             self.out("bader_retrieved", self.ctx.bader.outputs.retrieved)
+            common_utils.add_extras(self.inputs.structure, "surfaces", self.node.uuid)
             self.report("Work chain is finished")
             return None
 
@@ -225,6 +227,8 @@ class Cp2kScfWorkChain(Cp2kDiagWorkChain):
             self.out("output_parameters", self.ctx.diag_scf.outputs.output_parameters)
             self.out("remote_folder", self.ctx.diag_scf.outputs.remote_folder)
             self.out("retrieved", self.ctx.diag_scf.outputs.retrieved)
+            self.out("ot_retrieved", self.ctx.ot_scf.outputs.retrieved)
+            common_utils.add_extras(self.inputs.structure, "surfaces", self.node.uuid)
             self.report("Work chain is finished")
             return None
 
@@ -235,5 +239,7 @@ class Cp2kScfWorkChain(Cp2kDiagWorkChain):
         self.out("output_parameters", self.ctx.ot_scf.outputs.output_parameters)
         self.out("remote_folder", self.ctx.ot_scf.outputs.remote_folder)
         self.out("retrieved", self.ctx.ot_scf.outputs.retrieved)
+        self.out("ot_retrieved", self.ctx.ot_scf.outputs.retrieved)
+        common_utils.add_extras(self.inputs.structure, "surfaces", self.node.uuid)
         self.report("Work chain is finished")
         return None


### PR DESCRIPTION
Part of the aiida-nanotech-empa split-PR chain extracted from the full working reference branch feature/cp2k-dft-protocol-refactor. This PR depends on #197 (PR-A2).

Scope:
- expose the OT retrieved folder separately as ot_retrieved for SCF runs;
- tag the input structure extras so surfaces search can find SCF workchains;
- keep behavior limited to Cp2kScfWorkChain finalization paths.

Files touched:
- aiida_nanotech_empa/workflows/cp2k/scf_workchain.py

Validation:
- python -m py_compile scf_workchain.py
- compared patch against commit 1fca1fa from the full reference history.