### PR TITLE
PR-A4: CP2K SCF unfolding post-processing

### DIFF
--- a/aiida_nanotech_empa/plugins/__init__.py
+++ b/aiida_nanotech_empa/plugins/__init__.py
@@ -5,10 +5,12 @@ from .hrstm import HrstmCalculation
 from .overlap import OverlapCalculation
 from .sparse_overlap import SparseOverlapCalculation
 from .stm import StmCalculation
+from .unfolding import Cp2kUnfoldingCalculation
 
 __all__ = (
     "AfmCalculation",
     "BaderCalculation",
+    "Cp2kUnfoldingCalculation",
     "CubeHandlerCalculation",
     "HrstmCalculation",
     "OverlapCalculation",

--- a/aiida_nanotech_empa/plugins/unfolding.py
+++ b/aiida_nanotech_empa/plugins/unfolding.py
@@ -1,0 +1,86 @@
+from aiida import common, engine, orm
+
+
+DEFAULT_WFN_FILENAME = "aiida-RESTART.wfn"
+DEFAULT_XYZ_FILENAME = "aiida.coords.xyz"
+DEFAULT_CP2K_INPUT_FILENAME = "aiida.inp"
+DEFAULT_MATRIX_FILENAME = "aiida-overlap_matrix.out-1_0.Log"
+DEFAULT_OUTPUT_FILENAME = "unfolding_bands.npz"
+
+
+class Cp2kUnfoldingCalculation(engine.CalcJob):
+    @classmethod
+    def define(cls, spec):
+        super().define(spec)
+        spec.input(
+            "parent_calc_folder",
+            valid_type=orm.RemoteData,
+            help="CP2K diagonalization folder containing the WFN, coordinates, and CP2K input.",
+        )
+        spec.input("primitive_vectors", valid_type=orm.Str)
+        spec.input("path", valid_type=orm.Str, default=lambda: orm.Str("G-K-M-G"), required=False)
+        spec.input("lattice_type", valid_type=orm.Str, default=lambda: orm.Str("auto"), required=False)
+        spec.input("emin", valid_type=orm.Float, required=False)
+        spec.input("emax", valid_type=orm.Float, required=False)
+        spec.input("wfn_filename", valid_type=orm.Str, default=lambda: orm.Str(DEFAULT_WFN_FILENAME), required=False)
+        spec.input("xyz_filename", valid_type=orm.Str, default=lambda: orm.Str(DEFAULT_XYZ_FILENAME), required=False)
+        spec.input("cp2k_input_filename", valid_type=orm.Str, default=lambda: orm.Str(DEFAULT_CP2K_INPUT_FILENAME), required=False)
+        spec.input("matrix_filename", valid_type=orm.Str, default=lambda: orm.Str(DEFAULT_MATRIX_FILENAME), required=False)
+        spec.input("overlap_threshold", valid_type=orm.Float, default=lambda: orm.Float(1.0e-10), required=False)
+        spec.input("output_filename", valid_type=orm.Str, default=lambda: orm.Str(DEFAULT_OUTPUT_FILENAME), required=False)
+        spec.input("settings", valid_type=orm.Dict, default=lambda: orm.Dict(dict={}), required=False)
+        spec.input("metadata.options.withmpi", valid_type=bool, default=False)
+
+    def prepare_for_submission(self, folder):
+        settings = self.inputs.settings.get_dict() if "settings" in self.inputs else {}
+        output_filename = self.inputs.output_filename.value
+
+        codeinfo = common.CodeInfo()
+        codeinfo.code_uuid = self.inputs.code.uuid
+        codeinfo.cmdline_params = [
+            "parent_calc_folder/" + self.inputs.wfn_filename.value,
+            "parent_calc_folder/" + self.inputs.matrix_filename.value,
+            output_filename,
+            "--xyz",
+            "parent_calc_folder/" + self.inputs.xyz_filename.value,
+            "--cp2k-input",
+            "parent_calc_folder/" + self.inputs.cp2k_input_filename.value,
+            "--primitive-vectors",
+            self.inputs.primitive_vectors.value,
+            "--path",
+            self.inputs.path.value,
+            "--lattice-type",
+            self.inputs.lattice_type.value,
+            "--overlap-format",
+            "log",
+            "--overlap-threshold",
+            str(self.inputs.overlap_threshold.value),
+        ]
+        if "emin" in self.inputs:
+            codeinfo.cmdline_params.extend(["--emin", str(self.inputs.emin.value)])
+        if "emax" in self.inputs:
+            codeinfo.cmdline_params.extend(["--emax", str(self.inputs.emax.value)])
+
+        calcinfo = common.CalcInfo()
+        calcinfo.uuid = self.uuid
+        calcinfo.codes_info = [codeinfo]
+        calcinfo.remote_symlink_list = []
+        calcinfo.remote_copy_list = []
+        calcinfo.local_copy_list = []
+        calcinfo.retrieve_list = settings.pop("additional_retrieve_list", [output_filename])
+
+        comp_uuid = self.inputs.parent_calc_folder.computer.uuid
+        remote_path = self.inputs.parent_calc_folder.get_remote_path()
+        copy_info = (comp_uuid, remote_path, "parent_calc_folder/")
+        if self.inputs.code.computer.uuid == comp_uuid:
+            calcinfo.remote_symlink_list.append(copy_info)
+        else:
+            calcinfo.remote_copy_list.append(copy_info)
+
+        if settings:
+            raise common.InputValidationError(
+                "The following keys have been found in settings but were not understood: "
+                + ",".join(settings.keys())
+            )
+
+        return calcinfo

--- a/aiida_nanotech_empa/plugins/unfolding.py
+++ b/aiida_nanotech_empa/plugins/unfolding.py
@@ -6,6 +6,7 @@ DEFAULT_XYZ_FILENAME = "aiida.coords.xyz"
 DEFAULT_CP2K_INPUT_FILENAME = "aiida.inp"
 DEFAULT_MATRIX_FILENAME = "aiida-overlap_matrix.out-1_0.Log"
 DEFAULT_OUTPUT_FILENAME = "unfolding_bands.npz"
+DEFAULT_PDOS_PROJECTION_FILENAME = "unfolding_projections.npz"
 
 
 class Cp2kUnfoldingCalculation(engine.CalcJob):
@@ -28,6 +29,24 @@ class Cp2kUnfoldingCalculation(engine.CalcJob):
         spec.input("matrix_filename", valid_type=orm.Str, default=lambda: orm.Str(DEFAULT_MATRIX_FILENAME), required=False)
         spec.input("overlap_threshold", valid_type=orm.Float, default=lambda: orm.Float(1.0e-10), required=False)
         spec.input("output_filename", valid_type=orm.Str, default=lambda: orm.Str(DEFAULT_OUTPUT_FILENAME), required=False)
+        spec.input(
+            "parse_pdos_projections",
+            valid_type=orm.Bool,
+            default=lambda: orm.Bool(False),
+            required=False,
+        )
+        spec.input(
+            "pdos_projection_filename",
+            valid_type=orm.Str,
+            default=lambda: orm.Str(DEFAULT_PDOS_PROJECTION_FILENAME),
+            required=False,
+        )
+        spec.input(
+            "pdos_threshold",
+            valid_type=orm.Float,
+            default=lambda: orm.Float(1.0e-4),
+            required=False,
+        )
         spec.input("settings", valid_type=orm.Dict, default=lambda: orm.Dict(dict={}), required=False)
         spec.input("metadata.options.withmpi", valid_type=bool, default=False)
 
@@ -60,6 +79,17 @@ class Cp2kUnfoldingCalculation(engine.CalcJob):
             codeinfo.cmdline_params.extend(["--emin", str(self.inputs.emin.value)])
         if "emax" in self.inputs:
             codeinfo.cmdline_params.extend(["--emax", str(self.inputs.emax.value)])
+        if self.inputs.parse_pdos_projections.value:
+            codeinfo.cmdline_params.extend(
+                [
+                    "--pdos-glob",
+                    "parent_calc_folder/aiida-*list*-1.pdos",
+                    "--pdos-output",
+                    self.inputs.pdos_projection_filename.value,
+                    "--pdos-threshold",
+                    str(self.inputs.pdos_threshold.value),
+                ]
+            )
 
         calcinfo = common.CalcInfo()
         calcinfo.uuid = self.uuid
@@ -67,7 +97,10 @@ class Cp2kUnfoldingCalculation(engine.CalcJob):
         calcinfo.remote_symlink_list = []
         calcinfo.remote_copy_list = []
         calcinfo.local_copy_list = []
-        calcinfo.retrieve_list = settings.pop("additional_retrieve_list", [output_filename])
+        default_retrieve_list = [output_filename]
+        if self.inputs.parse_pdos_projections.value:
+            default_retrieve_list.append(self.inputs.pdos_projection_filename.value)
+        calcinfo.retrieve_list = settings.pop("additional_retrieve_list", default_retrieve_list)
 
         comp_uuid = self.inputs.parent_calc_folder.computer.uuid
         remote_path = self.inputs.parent_calc_folder.get_remote_path()

--- a/aiida_nanotech_empa/workflows/cp2k/scf_workchain.py
+++ b/aiida_nanotech_empa/workflows/cp2k/scf_workchain.py
@@ -5,6 +5,7 @@ from .diag_workchain import Cp2kDiagWorkChain
 
 BaderCalculation = plugins.CalculationFactory("nanotech_empa.bader")
 SparseOverlapCalculation = plugins.CalculationFactory("nanotech_empa.sparse_overlap")
+Cp2kUnfoldingCalculation = plugins.CalculationFactory("nanotech_empa.cp2k_unfolding")
 
 
 class Cp2kScfWorkChain(Cp2kDiagWorkChain):
@@ -65,6 +66,39 @@ class Cp2kScfWorkChain(Cp2kDiagWorkChain):
             required=False,
             help="Plane-wave cutoff used for the OT charge-density cube for Bader analysis.",
         )
+        spec.input(
+            "compute_unfolding",
+            valid_type=orm.Bool,
+            default=lambda: orm.Bool(False),
+            required=False,
+            help="Post-process WFN and sparse AO overlap into unfolded band weights.",
+        )
+        spec.input(
+            "unfolding_code",
+            valid_type=orm.Code,
+            required=False,
+            help="Python code configured for the nanotech_empa.cp2k_unfolding plugin.",
+        )
+        spec.input(
+            "unfolding_primitive_vectors",
+            valid_type=orm.Str,
+            required=False,
+            help="Approximate primitive vectors as rows, separated by semicolons or newlines.",
+        )
+        spec.input(
+            "unfolding_path",
+            valid_type=orm.Str,
+            default=lambda: orm.Str("G-K-M-G"),
+            required=False,
+            help="High-symmetry path labels, e.g. G-K-M-G.",
+        )
+        spec.input(
+            "unfolding_lattice_type",
+            valid_type=orm.Str,
+            default=lambda: orm.Str("auto"),
+            required=False,
+            help="1d, square, rectangular, hexagonal, oblique, or auto.",
+        )
         spec.outline(
             cls.setup,
             cls.run_ot_scf,
@@ -72,6 +106,9 @@ class Cp2kScfWorkChain(Cp2kDiagWorkChain):
                 cls.run_diag_scf,
                 engine.if_(cls.should_run_sparse_overlap)(
                     cls.run_sparse_overlap,
+                ),
+                engine.if_(cls.should_run_unfolding)(
+                    cls.run_unfolding,
                 ),
             ),
             engine.if_(cls.should_run_bader)(
@@ -89,6 +126,16 @@ class Cp2kScfWorkChain(Cp2kDiagWorkChain):
             "ERROR_MISSING_BADER_CODE",
             message="A Bader code is required to compute Bader charges.",
         )
+        spec.exit_code(
+            393,
+            "ERROR_MISSING_UNFOLDING_CODE",
+            message="An unfolding code is required to compute band unfolding.",
+        )
+        spec.exit_code(
+            394,
+            "ERROR_MISSING_UNFOLDING_PRIMITIVE_VECTORS",
+            message="Primitive vectors are required to compute band unfolding.",
+        )
 
     def should_run_diag_scf(self):
         if self.should_run_bader():
@@ -98,6 +145,7 @@ class Cp2kScfWorkChain(Cp2kDiagWorkChain):
         return (
             self.inputs.write_overlap_matrix.value
             or self.inputs.retrieve_sparse_overlap.value
+            or self.inputs.compute_unfolding.value
             or dft_params.get("added_mos", 0) > 0
         )
 
@@ -106,6 +154,9 @@ class Cp2kScfWorkChain(Cp2kDiagWorkChain):
 
     def should_run_sparse_overlap(self):
         return self.inputs.retrieve_sparse_overlap.value
+
+    def should_run_unfolding(self):
+        return self.inputs.compute_unfolding.value
 
     def update_ot_input_dict(self, input_dict):
         if not self.should_run_bader():
@@ -124,6 +175,7 @@ class Cp2kScfWorkChain(Cp2kDiagWorkChain):
         if not (
             self.inputs.write_overlap_matrix.value
             or self.inputs.retrieve_sparse_overlap.value
+            or self.inputs.compute_unfolding.value
         ):
             return
 
@@ -161,6 +213,36 @@ class Cp2kScfWorkChain(Cp2kDiagWorkChain):
             },
         }
         return engine.ToContext(sparse_overlap=self.submit(builder))
+
+    def run_unfolding(self):
+        if "unfolding_code" not in self.inputs:
+            return self.exit_codes.ERROR_MISSING_UNFOLDING_CODE
+        if "unfolding_primitive_vectors" not in self.inputs:
+            return self.exit_codes.ERROR_MISSING_UNFOLDING_PRIMITIVE_VECTORS
+
+        self.report("Running CP2K band unfolding post-processing")
+        builder = Cp2kUnfoldingCalculation.get_builder()
+        builder.code = self.inputs.unfolding_code
+        builder.parent_calc_folder = self.ctx.diag_scf.outputs.remote_folder
+        builder.primitive_vectors = self.inputs.unfolding_primitive_vectors
+        builder.path = self.inputs.unfolding_path
+        builder.lattice_type = self.inputs.unfolding_lattice_type
+        builder.overlap_threshold = self.inputs.overlap_threshold
+        builder.metadata = {
+            "label": "cp2k_unfolding",
+            "options": {
+                "resources": {
+                    "num_machines": 1,
+                    "num_mpiprocs_per_machine": 1,
+                    "num_cores_per_mpiproc": 1,
+                },
+                "max_wallclock_seconds": min(
+                    7200, self.ctx.options["max_wallclock_seconds"]
+                ),
+                "withmpi": False,
+            },
+        }
+        return engine.ToContext(unfolding=self.submit(builder))
 
     def run_bader(self):
         if "bader_code" not in self.inputs:
@@ -219,10 +301,17 @@ class Cp2kScfWorkChain(Cp2kDiagWorkChain):
                 if not common_utils.check_if_calc_ok(self, self.ctx.sparse_overlap):
                     self.report("sparse overlap post-processing failed")
                     return self.exit_codes.ERROR_TERMINATION
-                self.out(
-                    "sparse_overlap_retrieved",
-                    self.ctx.sparse_overlap.outputs.retrieved,
-                )
+                if self.inputs.retrieve_sparse_overlap.value:
+                    self.out(
+                        "sparse_overlap_retrieved",
+                        self.ctx.sparse_overlap.outputs.retrieved,
+                    )
+
+            if self.should_run_unfolding():
+                if not common_utils.check_if_calc_ok(self, self.ctx.unfolding):
+                    self.report("CP2K band unfolding post-processing failed")
+                    return self.exit_codes.ERROR_TERMINATION
+                self.out("unfolding_retrieved", self.ctx.unfolding.outputs.retrieved)
 
             self.out("output_parameters", self.ctx.diag_scf.outputs.output_parameters)
             self.out("remote_folder", self.ctx.diag_scf.outputs.remote_folder)

--- a/aiida_nanotech_empa/workflows/cp2k/scf_workchain.py
+++ b/aiida_nanotech_empa/workflows/cp2k/scf_workchain.py
@@ -99,6 +99,13 @@ class Cp2kScfWorkChain(Cp2kDiagWorkChain):
             required=False,
             help="1d, square, rectangular, hexagonal, oblique, or auto.",
         )
+        spec.input(
+            "unfolding_pdos_threshold",
+            valid_type=orm.Float,
+            default=lambda: orm.Float(1.0e-4),
+            required=False,
+            help="Projection threshold for compact atom-resolved PDOS data attached to unfolding.",
+        )
         spec.outline(
             cls.setup,
             cls.run_ot_scf,
@@ -192,6 +199,16 @@ class Cp2kScfWorkChain(Cp2kDiagWorkChain):
             "NDIGITS": self.inputs.overlap_ndigits.value,
         }
 
+        if self.inputs.compute_unfolding.value:
+            added_mos = int(self.ctx.dft_params.get("added_mos", 0))
+            print_section["PDOS"] = {
+                "LDOS": [
+                    {"COMPONENTS": "", "LIST": atom_index}
+                    for atom_index in range(1, self.ctx.n_atoms + 1)
+                ],
+                "NLUMO": added_mos,
+            }
+
     def run_sparse_overlap(self):
         if "sparse_overlap_code" not in self.inputs:
             return self.exit_codes.ERROR_MISSING_SPARSE_OVERLAP_CODE
@@ -233,6 +250,8 @@ class Cp2kScfWorkChain(Cp2kDiagWorkChain):
         builder.path = self.inputs.unfolding_path
         builder.lattice_type = self.inputs.unfolding_lattice_type
         builder.overlap_threshold = self.inputs.overlap_threshold
+        builder.parse_pdos_projections = orm.Bool(True)
+        builder.pdos_threshold = self.inputs.unfolding_pdos_threshold
         builder.metadata = {
             "label": "cp2k_unfolding",
             "options": {
@@ -323,6 +342,16 @@ class Cp2kScfWorkChain(Cp2kDiagWorkChain):
                 if output_filename not in retrieved_names:
                     self.report(f"CP2K band unfolding did not retrieve {output_filename}")
                     return self.exit_codes.ERROR_MISSING_UNFOLDING_OUTPUT
+                if self.ctx.unfolding.inputs.parse_pdos_projections.value:
+                    projection_filename = (
+                        self.ctx.unfolding.inputs.pdos_projection_filename.value
+                    )
+                    if projection_filename not in retrieved_names:
+                        self.report(
+                            "CP2K band unfolding did not retrieve "
+                            f"{projection_filename}"
+                        )
+                        return self.exit_codes.ERROR_MISSING_UNFOLDING_OUTPUT
                 self.out("unfolding_retrieved", self.ctx.unfolding.outputs.retrieved)
 
             self.out("output_parameters", self.ctx.diag_scf.outputs.output_parameters)

--- a/aiida_nanotech_empa/workflows/cp2k/scf_workchain.py
+++ b/aiida_nanotech_empa/workflows/cp2k/scf_workchain.py
@@ -136,6 +136,11 @@ class Cp2kScfWorkChain(Cp2kDiagWorkChain):
             "ERROR_MISSING_UNFOLDING_PRIMITIVE_VECTORS",
             message="Primitive vectors are required to compute band unfolding.",
         )
+        spec.exit_code(
+            395,
+            "ERROR_MISSING_UNFOLDING_OUTPUT",
+            message="CP2K band unfolding finished without retrieving unfolding_bands.npz.",
+        )
 
     def should_run_diag_scf(self):
         if self.should_run_bader():
@@ -311,6 +316,13 @@ class Cp2kScfWorkChain(Cp2kDiagWorkChain):
                 if not common_utils.check_if_calc_ok(self, self.ctx.unfolding):
                     self.report("CP2K band unfolding post-processing failed")
                     return self.exit_codes.ERROR_TERMINATION
+                output_filename = self.ctx.unfolding.inputs.output_filename.value
+                retrieved_names = (
+                    self.ctx.unfolding.outputs.retrieved.base.repository.list_object_names()
+                )
+                if output_filename not in retrieved_names:
+                    self.report(f"CP2K band unfolding did not retrieve {output_filename}")
+                    return self.exit_codes.ERROR_MISSING_UNFOLDING_OUTPUT
                 self.out("unfolding_retrieved", self.ctx.unfolding.outputs.retrieved)
 
             self.out("output_parameters", self.ctx.diag_scf.outputs.output_parameters)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ dev = [
 "nanotech_empa.overlap" = "aiida_nanotech_empa.plugins:OverlapCalculation"
 "nanotech_empa.sparse_overlap" = "aiida_nanotech_empa.plugins:SparseOverlapCalculation"
 "nanotech_empa.bader" = "aiida_nanotech_empa.plugins:BaderCalculation"
+"nanotech_empa.cp2k_unfolding" = "aiida_nanotech_empa.plugins:Cp2kUnfoldingCalculation"
 "nanotech_empa.afm" = "aiida_nanotech_empa.plugins:AfmCalculation"
 "nanotech_empa.hrstm" = "aiida_nanotech_empa.plugins:HrstmCalculation"
 "nanotech_empa.cubehandler" = "aiida_nanotech_empa.plugins:CubeHandlerCalculation"


### PR DESCRIPTION
Part of the aiida-nanotech-empa split-PR chain extracted from the full working reference branch feature/cp2k-dft-protocol-refactor. This PR depends on #198 (PR-A3).

Scope:
- add Cp2kUnfoldingCalculation CalcJob and entry point;
- add optional unfolding post-processing to Cp2kScfWorkChain;
- validate that unfolding_bands.npz is retrieved;
- enable compact atom-resolved PDOS projection parsing for unfolding runs.

Files touched:
- aiida_nanotech_empa/plugins/__init__.py
- aiida_nanotech_empa/plugins/unfolding.py
- aiida_nanotech_empa/workflows/cp2k/scf_workchain.py
- pyproject.toml

Validation:
- python -m py_compile on unfolding.py and scf_workchain.py
- compared against commits 7b5480c, 95cd635, and c417452 from the full reference history.

Note:
- MPI resources and primitive-basis-atom refinements are intentionally left for a later DFT/MPI refinement PR.