### PR TITLE
PR-A5: Guard empty fixed-atom fragments

### DIFF
--- a/aiida_nanotech_empa/utils/split_structure.py
+++ b/aiida_nanotech_empa/utils/split_structure.py
@@ -9,7 +9,7 @@ def split_structure(structure, fixed_atoms, magnetization_per_site, fragments):
 
     allfixed = [0 for i in ase_geo]
     mps = []
-    fixed = ""
+    fixed = []
     if "all" not in fragments:
         yield {
             "label": "all",
@@ -50,6 +50,8 @@ def split_structure(structure, fixed_atoms, magnetization_per_site, fragments):
         yield {
             "label": fragment_label,
             "structure": StructureData(ase=ase_geo[fragment]),
-            "fixed_atoms": orm.List(list=np.nonzero(fixed)[0].tolist()),
+            "fixed_atoms": orm.List(
+                list=[index for index, is_fixed in enumerate(fixed) if is_fixed]
+            ),
             "magnetization_per_site": orm.List(list=mps),
         }


### PR DESCRIPTION
Part of the aiida-nanotech-empa split-PR chain extracted from the full working reference branch feature/cp2k-dft-protocol-refactor. This PR depends on #199 (PR-A4).

Scope:
- handle empty fixed-atom fragment selections in split_structure;
- avoid crashing fragment/splitter workflows when a fragment selection contains no fixed atoms.

Files touched:
- aiida_nanotech_empa/utils/split_structure.py

Validation:
- python -m py_compile split_structure.py
- compared patch against commit 625e8a2 from the full reference history.