### PR TITLE
PR-A7: Configurable CP2K DFT settings helpers

### DIFF
--- a/aiida_nanotech_empa/workflows/cp2k/cp2k_utils.py
+++ b/aiida_nanotech_empa/workflows/cp2k/cp2k_utils.py
@@ -1,7 +1,6 @@
 import collections
 import io
 import numbers
-import os
 import pathlib
 import re
 import shutil
@@ -11,6 +10,8 @@ import ase
 import numpy as np
 import yaml
 from aiida import common, orm
+
+DATA_DIR = pathlib.Path(__file__).parent / "data"
 
 
 class SizeDifferentThanNumberOfAtomsError(ValueError):
@@ -22,9 +23,67 @@ class SizeDifferentThanNumberOfAtomsError(ValueError):
         )
 
 
-def get_kinds_section(kinds_dict, protocol="gapw_std"):
-    """Write the &KIND sections in gw calculations given the structure and the settings_dict"""
+def _as_list(value):
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value]
+    return list(value)
 
+
+def get_dft_file_names(dft_params=None):
+    """Return CP2K file names, keeping the historical PBE defaults."""
+
+    dft_params = dft_params or {}
+    basis_files = dft_params.get(
+        "basis_set_file_names",
+        dft_params.get("basis_set_file_name", "BASIS_MOLOPT"),
+    )
+    potential_file = dft_params.get("potential_file_name", "POTENTIAL")
+
+    return {
+        "basis_set_file_names": _as_list(basis_files),
+        "potential_file_name": potential_file,
+    }
+
+
+def get_dft_file_inputs(dft_params=None):
+    """Build SinglefileData inputs for CP2K data files packaged with the plugin."""
+
+    file_names = get_dft_file_names(dft_params)
+    files = {}
+    for index, file_name in enumerate(file_names["basis_set_file_names"]):
+        key = "basis" if index == 0 else f"basis_{index + 1}"
+        files[key] = orm.SinglefileData(file=DATA_DIR / file_name)
+    files["pseudo"] = orm.SinglefileData(
+        file=DATA_DIR / file_names["potential_file_name"]
+    )
+    return files
+
+
+def apply_dft_file_names(input_dict, dft_params=None):
+    """Apply CP2K BASIS_SET_FILE_NAME and POTENTIAL_FILE_NAME from dft_params."""
+
+    file_names = get_dft_file_names(dft_params)
+    dft_section = input_dict["FORCE_EVAL"]["DFT"]
+    basis_files = file_names["basis_set_file_names"]
+    dft_section["BASIS_SET_FILE_NAME"] = (
+        basis_files[0] if len(basis_files) == 1 else basis_files
+    )
+    dft_section["POTENTIAL_FILE_NAME"] = file_names["potential_file_name"]
+
+
+def _get_kind_value(atom_data, key, element, overrides=None):
+    overrides = overrides or {}
+    if element in overrides:
+        return overrides[element]
+    return atom_data[key][element]
+
+
+def get_kinds_section(kinds_dict, protocol="gapw_std", dft_params=None):
+    """Write the &KIND sections given the structure and DFT settings."""
+
+    dft_params = dft_params or {}
     bset = "gapw_std_gw_basis_set"
     bsetaux = "gapw_std_gw_basis_set_aux"
     potential = "all"
@@ -40,10 +99,15 @@ def get_kinds_section(kinds_dict, protocol="gapw_std"):
         bset = "basis_set"
         bsetaux = ""
         potential = "pseudopotential"
+
+    bset = dft_params.get("basis_set_key", bset)
+    bsetaux = dft_params.get("aux_basis_set_key", bsetaux)
+    potential = dft_params.get("potential_key", potential)
+    basis_overrides = dft_params.get("basis_set_overrides", {})
+    aux_basis_overrides = dft_params.get("aux_basis_set_overrides", {})
+    potential_overrides = dft_params.get("potential_overrides", {})
     kinds = []
-    with open(
-        pathlib.Path(__file__).parent / "./data/atomic_kinds.yml", encoding="utf-8"
-    ) as fhandle:
+    with open(DATA_DIR / "atomic_kinds.yml", encoding="utf-8") as fhandle:
         atom_data = yaml.safe_load(fhandle)
 
     for kind_name in kinds_dict:
@@ -52,12 +116,16 @@ def get_kinds_section(kinds_dict, protocol="gapw_std"):
         is_ghost = kinds_dict[kind_name]["ghost"]
         new_section = {
             "_": kind_name,
-            "BASIS_SET": atom_data[bset][element],
-            "POTENTIAL": atom_data[potential][element],
+            "BASIS_SET": _get_kind_value(atom_data, bset, element, basis_overrides),
+            "POTENTIAL": _get_kind_value(
+                atom_data, potential, element, potential_overrides
+            ),
             "ELEMENT": element,
         }
         if bsetaux:
-            new_section["BASIS_SET RI_AUX"] = atom_data[bsetaux][element]
+            new_section["BASIS_SET RI_AUX"] = _get_kind_value(
+                atom_data, bsetaux, element, aux_basis_overrides
+            )
         if is_ghost:
             new_section["GHOST"] = "TRUE"
         if magnetization != 0.0:
@@ -165,9 +233,7 @@ def dict_merge(dct, merge_dct):
 def get_cutoff(structure=None):
     if structure is None:
         return int(600)
-    with open(
-        pathlib.Path(__file__).parent / "./data/atomic_kinds.yml", encoding="utf-8"
-    ) as fhandle:
+    with open(DATA_DIR / "atomic_kinds.yml", encoding="utf-8") as fhandle:
         atom_data = yaml.safe_load(fhandle)
     elements = structure.get_symbols_set()
     return max([atom_data["cutoff"][element] for element in elements])
@@ -182,25 +248,60 @@ def load_protocol(fname, protocol=None):
         return protocols[protocol] if protocol else protocols
 
 
-def get_dft_inputs(dft_params, structure, template, protocol):
-    files = {
-        "basis": orm.SinglefileData(
-            file=os.path.join(
-                os.path.dirname(os.path.realpath(__file__)),
-                ".",
-                "data",
-                "BASIS_MOLOPT",
-            )
+def apply_xc_settings(input_dict, dft_params=None):
+    """Apply additive XC settings while preserving the legacy PBE input by default."""
+
+    dft_params = dft_params or {}
+    xc_section = input_dict["FORCE_EVAL"]["DFT"]["XC"]
+    functional = dft_params.get("xc_functional", dft_params.get("functional", "PBE"))
+    functional = str(functional).upper()
+
+    if functional in ("PBE", "PBE-D3", "PBE_D3"):
+        return
+
+    if functional != "PBE0":
+        raise ValueError(f"Unsupported CP2K XC functional: {functional}")
+
+    hfx_fraction = dft_params.get("hfx_fraction", 0.25)
+    hfx_cutoff_radius = dft_params.get("hfx_cutoff_radius", 10.0)
+    input_dict["FORCE_EVAL"]["DFT"]["AUXILIARY_DENSITY_MATRIX_METHOD"] = {
+        "ADMM_PURIFICATION_METHOD": dft_params.get(
+            "admm_purification_method", "MO_DIAG"
         ),
-        "pseudo": orm.SinglefileData(
-            file=os.path.join(
-                os.path.dirname(os.path.realpath(__file__)),
-                ".",
-                "data",
-                "POTENTIAL",
-            )
-        ),
+        "METHOD": dft_params.get("admm_method", "BASIS_PROJECTION"),
     }
+    xc_section["DENSITY_CUTOFF"] = dft_params.get("xc_density_cutoff", 1e-10)
+    xc_section["GRADIENT_CUTOFF"] = dft_params.get("xc_gradient_cutoff", 1e-10)
+    xc_section["TAU_CUTOFF"] = dft_params.get("xc_tau_cutoff", 1e-10)
+    xc_section["XC_FUNCTIONAL"] = {
+        "_": "NO_SHORTCUT",
+        "PBE": {"_": "T", "SCALE_X": 1.0 - hfx_fraction, "SCALE_C": 1.0},
+        "PBE_HOLE_T_C_LR": {
+            "_": "T",
+            "SCALE_X": hfx_fraction,
+            "CUTOFF_RADIUS": hfx_cutoff_radius,
+        },
+    }
+    xc_section["HF"] = {
+        "FRACTION": hfx_fraction,
+        "SCREENING": {
+            "EPS_SCHWARZ": dft_params.get("eps_schwarz", 1e-8),
+            "SCREEN_ON_INITIAL_P": dft_params.get("screen_on_initial_p", "F"),
+        },
+        "INTERACTION_POTENTIAL": {
+            "POTENTIAL_TYPE": dft_params.get("hfx_potential_type", "TRUNCATED"),
+            "CUTOFF_RADIUS": hfx_cutoff_radius,
+            "T_C_G_DATA": dft_params.get("tcg_data_file_name", "t_c_g.dat"),
+        },
+        "MEMORY": {
+            "EPS_STORAGE_SCALING": dft_params.get("hfx_eps_storage_scaling", 0.1),
+            "MAX_MEMORY": dft_params.get("hfx_max_memory", 80000),
+        },
+    }
+
+
+def get_dft_inputs(dft_params, structure, template, protocol):
+    files = get_dft_file_inputs(dft_params)
 
     # number of atoms
     if isinstance(structure, orm.TrajectoryData):
@@ -216,6 +317,7 @@ def get_dft_inputs(dft_params, structure, template, protocol):
 
     # Load input template.
     input_dict = load_protocol(template, protocol)
+    apply_dft_file_names(input_dict, dft_params)
 
     # vdW section
     if "vdw" in dft_params:
@@ -223,6 +325,8 @@ def get_dft_inputs(dft_params, structure, template, protocol):
             input_dict["FORCE_EVAL"]["DFT"]["XC"].pop("VDW_POTENTIAL")
     else:
         input_dict["FORCE_EVAL"]["DFT"]["XC"].pop("VDW_POTENTIAL")
+
+    apply_xc_settings(input_dict, dft_params)
 
     # charge
     if "charge" in dft_params:
@@ -260,7 +364,7 @@ def get_dft_inputs(dft_params, structure, template, protocol):
 
     # must be after if 'periodic'
     structure_with_tags = ase_atoms
-    kinds_section = get_kinds_section(kinds_dict, protocol="gpw")
+    kinds_section = get_kinds_section(kinds_dict, protocol="gpw", dft_params=dft_params)
     dict_merge(input_dict, kinds_section)
 
     # get cutoff.

--- a/aiida_nanotech_empa/workflows/cp2k/diag_workchain.py
+++ b/aiida_nanotech_empa/workflows/cp2k/diag_workchain.py
@@ -1,6 +1,4 @@
 import copy
-import pathlib
-
 import numpy as np
 from aiida import engine, orm, plugins
 
@@ -103,19 +101,12 @@ class Cp2kDiagWorkChain(engine.WorkChain):
 
     def setup(self):
         self.report("Setting up workchain")
-        self.ctx.files = {
-            "basis": orm.SinglefileData(
-                file=pathlib.Path(__file__).parent / "data" / "BASIS_MOLOPT",
-            ),
-            "pseudo": orm.SinglefileData(
-                file=pathlib.Path(__file__).parent / "data" / "POTENTIAL",
-            ),
-        }
+        self.ctx.dft_params = self.inputs.dft_params.get_dict()
+        self.ctx.files = cp2k_utils.get_dft_file_inputs(self.ctx.dft_params)
 
         structure = self.inputs.structure
         self.ctx.n_atoms = len(structure.sites)
 
-        self.ctx.dft_params = self.inputs.dft_params.get_dict()
         self.ctx.dft_params.setdefault("periodic", "XYZ")
         self.ctx.dft_params.setdefault("uks", False)
         self.ctx.dft_params.setdefault("elpa_switch", False)
@@ -143,7 +134,7 @@ class Cp2kDiagWorkChain(engine.WorkChain):
         self._handle_periodicity(self.ctx.structure_with_tags)
 
         self.ctx.kinds_section = cp2k_utils.get_kinds_section(
-            kinds_dict, protocol="gpw"
+            kinds_dict, protocol="gpw", dft_params=self.ctx.dft_params
         )
 
     def _handle_periodicity(self, structure):
@@ -163,6 +154,7 @@ class Cp2kDiagWorkChain(engine.WorkChain):
         input_dict = cp2k_utils.load_protocol(
             "scf_ot_protocol.yml", self.inputs.protocol.value
         )
+        cp2k_utils.apply_dft_file_names(input_dict, self.ctx.dft_params)
 
         # Set workflow inputs.
         builder = Cp2kBaseWorkChain.get_builder()
@@ -178,6 +170,7 @@ class Cp2kDiagWorkChain(engine.WorkChain):
         if "charge" in self.ctx.dft_params:
             input_dict["FORCE_EVAL"]["DFT"]["CHARGE"] = self.ctx.dft_params["charge"]
         input_dict["FORCE_EVAL"]["DFT"]["XC"].pop("VDW_POTENTIAL")
+        cp2k_utils.apply_xc_settings(input_dict, self.ctx.dft_params)
 
         # POISSON_SOLVER
         if self.ctx.dft_params["periodic"] == "NONE":

--- a/aiida_nanotech_empa/workflows/cp2k/geo_opt_workchain.py
+++ b/aiida_nanotech_empa/workflows/cp2k/geo_opt_workchain.py
@@ -1,5 +1,3 @@
-import pathlib
-
 import numpy as np
 from aiida import engine, orm, plugins
 
@@ -101,20 +99,13 @@ class Cp2kGeoOptWorkChain(engine.WorkChain):
     def setup(self):
         self.report("Inspecting input and setting up things")
 
-        self.ctx.files = {
-            "basis": orm.SinglefileData(
-                file=pathlib.Path(__file__).parent / "data" / "BASIS_MOLOPT"
-            ),
-            "pseudo": orm.SinglefileData(
-                file=pathlib.Path(__file__).parent / "data" / "POTENTIAL"
-            ),
-        }
-
         self.ctx.sys_params = self.inputs.sys_params.get_dict()
         self.ctx.dft_params = self.inputs.dft_params.get_dict()
+        self.ctx.files = cp2k_utils.get_dft_file_inputs(self.ctx.dft_params)
         self.ctx.input_dict = cp2k_utils.load_protocol(
             "geo_opt_protocol.yml", self.inputs.protocol.value
         )
+        cp2k_utils.apply_dft_file_names(self.ctx.input_dict, self.ctx.dft_params)
 
         # vdW section.
         if "vdw" in self.ctx.dft_params:
@@ -122,6 +113,8 @@ class Cp2kGeoOptWorkChain(engine.WorkChain):
                 self.ctx.input_dict["FORCE_EVAL"]["DFT"]["XC"].pop("VDW_POTENTIAL")
         else:
             self.ctx.input_dict["FORCE_EVAL"]["DFT"]["XC"].pop("VDW_POTENTIAL")
+
+        cp2k_utils.apply_xc_settings(self.ctx.input_dict, self.ctx.dft_params)
 
         # Charge.
         if "charge" in self.ctx.dft_params:
@@ -166,7 +159,7 @@ class Cp2kGeoOptWorkChain(engine.WorkChain):
 
         self.ctx.structure_with_tags = ase_atoms
         self.ctx.kinds_section = cp2k_utils.get_kinds_section(
-            kinds_dict, protocol="gpw"
+            kinds_dict, protocol="gpw", dft_params=self.ctx.dft_params
         )
         cp2k_utils.dict_merge(self.ctx.input_dict, self.ctx.kinds_section)
 


### PR DESCRIPTION
Part of the aiida-nanotech-empa split-PR chain extracted from the full working reference branch feature/cp2k-dft-protocol-refactor. This PR depends on #201 (PR-A6).

Scope:
- add CP2K DFT helper functions for configurable basis/potential file names;
- support basis, auxiliary-basis, and potential map keys and per-element overrides;
- thread dft_params through KIND generation for diag and geometry optimization workflows;
- preserve historical PBE defaults unless new DFT params are provided.

Files touched:
- aiida_nanotech_empa/workflows/cp2k/cp2k_utils.py
- aiida_nanotech_empa/workflows/cp2k/diag_workchain.py
- aiida_nanotech_empa/workflows/cp2k/geo_opt_workchain.py

Validation:
- python -m py_compile on cp2k_utils.py, diag_workchain.py, and geo_opt_workchain.py
- compared patch against commit ec6eec5 from the full reference history.