### PR TITLE
PR-A9: PBE0 diagonalization and PDOS basis fixes

### DIFF
--- a/aiida_nanotech_empa/workflows/cp2k/cp2k_utils.py
+++ b/aiida_nanotech_empa/workflows/cp2k/cp2k_utils.py
@@ -276,7 +276,7 @@ def load_protocol(fname, protocol=None):
         return protocols[protocol] if protocol else protocols
 
 
-def apply_xc_settings(input_dict, dft_params=None):
+def apply_xc_settings(input_dict, dft_params=None, scf_method="ot"):
     """Apply additive XC settings while preserving the legacy PBE input by default."""
 
     dft_params = dft_params or {}
@@ -291,9 +291,10 @@ def apply_xc_settings(input_dict, dft_params=None):
 
     hfx_fraction = dft_params.get("hfx_fraction", 0.25)
     hfx_cutoff_radius = dft_params.get("hfx_cutoff_radius", 10.0)
+    default_purification = "NONE" if scf_method == "diag" else "MO_DIAG"
     input_dict["FORCE_EVAL"]["DFT"]["AUXILIARY_DENSITY_MATRIX_METHOD"] = {
         "ADMM_PURIFICATION_METHOD": dft_params.get(
-            "admm_purification_method", "MO_DIAG"
+            "admm_purification_method", default_purification
         ),
         "METHOD": dft_params.get("admm_method", "BASIS_PROJECTION"),
     }

--- a/aiida_nanotech_empa/workflows/cp2k/diag_workchain.py
+++ b/aiida_nanotech_empa/workflows/cp2k/diag_workchain.py
@@ -234,6 +234,7 @@ class Cp2kDiagWorkChain(engine.WorkChain):
             input_dict["GLOBAL"]["DBCSR"] = {"USE_MPI_ALLOCATOR": ".FALSE."}
         input_dict["FORCE_EVAL"]["DFT"].pop("SCF")
         input_dict["FORCE_EVAL"]["DFT"]["SCF"] = scf_dict
+        cp2k_utils.apply_xc_settings(input_dict, self.ctx.dft_params, scf_method="diag")
         if "added_mos" in self.ctx.dft_params:
             input_dict["FORCE_EVAL"]["DFT"]["SCF"]["ADDED_MOS"] = self.ctx.dft_params[
                 "added_mos"

--- a/aiida_nanotech_empa/workflows/cp2k/pdos_workchain.py
+++ b/aiida_nanotech_empa/workflows/cp2k/pdos_workchain.py
@@ -202,7 +202,13 @@ class Cp2kPdosWorkChain(engine.WorkChain):
         self.report("Running overlap")
         builder = OverlapCalculation.get_builder()
         builder.code = self.inputs.overlap_code
-        builder.parameters = self.inputs.overlap_params
+        overlap_params = self.inputs.overlap_params.get_dict()
+        basis_file = cp2k_utils.get_dft_file_names(self.ctx.dft_parameters)[
+            "basis_set_file_names"
+        ][0]
+        overlap_params["--basis_set_file1"] = f"parent_slab_folder/{basis_file}"
+        overlap_params["--basis_set_file2"] = f"parent_mol_folder/{basis_file}"
+        builder.parameters = orm.Dict(overlap_params)
         builder.parent_slab_folder = self.ctx.slab_diag_scf.outputs.remote_folder
         builder.parent_mol_folder = self.ctx.mol_diag_scf.outputs.remote_folder
 


### PR DESCRIPTION
Part of the aiida-nanotech-empa split-PR chain extracted from the full working reference branch feature/cp2k-dft-protocol-refactor. This PR depends on #203 (PR-A8).

Scope:
- use ADMM_PURIFICATION_METHOD NONE by default for PBE0 diagonalization, where MO-based purification is incompatible with diagonalization;
- preserve the active CP2K basis file when launching PDOS overlap post-processing instead of assuming BASIS_MOLOPT.

Files touched:
- aiida_nanotech_empa/workflows/cp2k/cp2k_utils.py
- aiida_nanotech_empa/workflows/cp2k/diag_workchain.py
- aiida_nanotech_empa/workflows/cp2k/pdos_workchain.py

Validation:
- python -m py_compile on cp2k_utils.py, diag_workchain.py, and pdos_workchain.py
- compared patches against commits 74b859a and d258235 from the full reference history.