### PR TITLE
PR-A10: Flexible DFT settings and MPI unfolding

### DIFF
--- a/aiida_nanotech_empa/plugins/unfolding.py
+++ b/aiida_nanotech_empa/plugins/unfolding.py
@@ -28,6 +28,8 @@ class Cp2kUnfoldingCalculation(engine.CalcJob):
         spec.input("cp2k_input_filename", valid_type=orm.Str, default=lambda: orm.Str(DEFAULT_CP2K_INPUT_FILENAME), required=False)
         spec.input("matrix_filename", valid_type=orm.Str, default=lambda: orm.Str(DEFAULT_MATRIX_FILENAME), required=False)
         spec.input("overlap_threshold", valid_type=orm.Float, default=lambda: orm.Float(1.0e-10), required=False)
+        spec.input("basis_cluster_tol", valid_type=orm.Float, default=lambda: orm.Float(5.0e-2), required=False)
+        spec.input("primitive_basis_atoms", valid_type=orm.Str, required=False)
         spec.input("output_filename", valid_type=orm.Str, default=lambda: orm.Str(DEFAULT_OUTPUT_FILENAME), required=False)
         spec.input(
             "parse_pdos_projections",
@@ -74,7 +76,14 @@ class Cp2kUnfoldingCalculation(engine.CalcJob):
             "log",
             "--overlap-threshold",
             str(self.inputs.overlap_threshold.value),
+            "--basis-cluster-tol",
+            str(self.inputs.basis_cluster_tol.value),
         ]
+        if "primitive_basis_atoms" in self.inputs:
+            codeinfo.cmdline_params.extend([
+                "--primitive-basis-atoms",
+                self.inputs.primitive_basis_atoms.value,
+            ])
         if "emin" in self.inputs:
             codeinfo.cmdline_params.extend(["--emin", str(self.inputs.emin.value)])
         if "emax" in self.inputs:

--- a/aiida_nanotech_empa/workflows/cp2k/cp2k_utils.py
+++ b/aiida_nanotech_empa/workflows/cp2k/cp2k_utils.py
@@ -65,6 +65,33 @@ def get_dft_file_names(dft_params=None):
     }
 
 
+def get_primary_basis_file_name(dft_params=None):
+    """Return the main orbital basis file name used by CP2K."""
+
+    return get_dft_file_names(dft_params)["basis_set_file_names"][0]
+
+
+def update_legacy_basis_parameter(
+    parameters, dft_params=None, key="--basis_set_file", parent_dir="parent_calc_folder"
+):
+    """Replace only the historical BASIS_MOLOPT default with the DFT basis file.
+
+    Explicit user-provided basis file paths are preserved. This only corrects the
+    old generated default when PBE0 or custom DFT settings use another primary
+    orbital basis file.
+    """
+
+    params = dict(parameters)
+    current_value = params.get(key)
+    primary_basis = get_primary_basis_file_name(dft_params)
+    legacy_default = f"{parent_dir}/BASIS_MOLOPT"
+    if current_value is None:
+        params[key] = f"{parent_dir}/{primary_basis}"
+    elif current_value == legacy_default and primary_basis != "BASIS_MOLOPT":
+        params[key] = f"{parent_dir}/{primary_basis}"
+    return params
+
+
 def get_dft_file_inputs(dft_params=None):
     """Build SinglefileData inputs for CP2K data files packaged with the plugin."""
 
@@ -276,11 +303,75 @@ def load_protocol(fname, protocol=None):
         return protocols[protocol] if protocol else protocols
 
 
+def _quote_cp2k_file_name(value):
+    """Return a CP2K string literal for file names that need explicit quotes."""
+
+    text = str(value)
+    if (text.startswith('"') and text.endswith('"')) or (
+        text.startswith("'") and text.endswith("'")
+    ):
+        return text
+    return f'"{text}"'
+
+
+def _apply_ot_minimizer(input_dict, dft_params):
+    """Apply the optional OT minimizer override without changing legacy defaults."""
+
+    try:
+        ot_section = input_dict["FORCE_EVAL"]["DFT"]["SCF"]["OT"]
+    except KeyError:
+        return
+    if not isinstance(ot_section, dict):
+        return
+
+    if dft_params.get("ot_diis", False):
+        minimizer = "DIIS"
+    else:
+        minimizer = dft_params.get("ot_minimizer")
+    if minimizer:
+        ot_section["MINIMIZER"] = str(minimizer).upper()
+
+
+def _pbe0_scf_section(dft_params, old_scf):
+    """Build the PBE0 OT SCF section, preserving protocol precision and PRINT."""
+
+    old_scf = old_scf if isinstance(old_scf, dict) else {}
+    old_outer_scf = old_scf.get("OUTER_SCF", {})
+    if not isinstance(old_outer_scf, dict):
+        old_outer_scf = {}
+    protocol_eps_scf = old_scf.get("EPS_SCF", 1e-7)
+    protocol_outer_eps_scf = old_outer_scf.get("EPS_SCF", protocol_eps_scf)
+
+    scf_section = {
+        "MAX_ITER_LUMO": dft_params.get("max_iter_lumo", 5000),
+        "EPS_LUMO": dft_params.get("eps_lumo", protocol_eps_scf),
+        "MAX_SCF": dft_params.get("max_scf", 20),
+        "EPS_SCF": dft_params.get("eps_scf", protocol_eps_scf),
+        "SCF_GUESS": dft_params.get("scf_guess", "RESTART"),
+        "OT": {
+            "_": "T",
+            "MINIMIZER": str(dft_params.get("ot_minimizer", "CG")).upper(),
+            "PRECONDITIONER": dft_params.get("ot_preconditioner", "FULL_KINETIC"),
+        },
+        "OUTER_SCF": {
+            "_": "T",
+            "EPS_SCF": dft_params.get("outer_scf_eps_scf", protocol_outer_eps_scf),
+            "MAX_SCF": dft_params.get("outer_scf_max_scf", 100),
+        },
+    }
+    if dft_params.get("ot_diis", False):
+        scf_section["OT"]["MINIMIZER"] = "DIIS"
+    if isinstance(old_scf, dict) and "PRINT" in old_scf:
+        scf_section["PRINT"] = old_scf["PRINT"]
+    return scf_section
+
+
 def apply_xc_settings(input_dict, dft_params=None, scf_method="ot"):
-    """Apply additive XC settings while preserving the legacy PBE input by default."""
+    """Apply XC/SCF settings while preserving legacy PBE inputs by default."""
 
     dft_params = dft_params or {}
-    xc_section = input_dict["FORCE_EVAL"]["DFT"]["XC"]
+    dft_section = input_dict["FORCE_EVAL"]["DFT"]
+    _apply_ot_minimizer(input_dict, dft_params)
     functional = _xc_functional(dft_params)
 
     if functional in ("PBE", "PBE-D3", "PBE_D3"):
@@ -291,13 +382,37 @@ def apply_xc_settings(input_dict, dft_params=None, scf_method="ot"):
 
     hfx_fraction = dft_params.get("hfx_fraction", 0.25)
     hfx_cutoff_radius = dft_params.get("hfx_cutoff_radius", 10.0)
-    default_purification = "NONE" if scf_method == "diag" else "MO_DIAG"
-    input_dict["FORCE_EVAL"]["DFT"]["AUXILIARY_DENSITY_MATRIX_METHOD"] = {
-        "ADMM_PURIFICATION_METHOD": dft_params.get(
-            "admm_purification_method", default_purification
-        ),
+
+    qs_section = dft_section.setdefault("QS", {})
+    for old_key in ("EPS_DEFAULT", "EXTRAPOLATION", "EXTRAPOLATION_ORDER"):
+        qs_section.pop(old_key, None)
+    qs_section["METHOD"] = dft_params.get("qs_method", qs_section.get("METHOD", "GPW"))
+    qs_section["EPS_PGF_ORB"] = dft_params.get("eps_pgf_orb", 1e-32)
+
+    if scf_method == "ot":
+        dft_section["SCF"] = _pbe0_scf_section(
+            dft_params, dft_section.get("SCF", {})
+        )
+
+    dft_section["AUXILIARY_DENSITY_MATRIX_METHOD"] = {
+        "ADMM_PURIFICATION_METHOD": str(
+            dft_params.get("admm_purification_method", "NONE")
+        ).upper(),
         "METHOD": dft_params.get("admm_method", "BASIS_PROJECTION"),
+        "EXCH_CORRECTION_FUNC": dft_params.get(
+            "admm_exch_correction_func", "PBEX"
+        ),
     }
+
+    xc_section = dft_section.setdefault("XC", {})
+    if dft_params.get("vdw", False):
+        pair_potential = xc_section.get("VDW_POTENTIAL", {}).get("PAIR_POTENTIAL")
+        if isinstance(pair_potential, dict):
+            pair_potential["REFERENCE_FUNCTIONAL"] = dft_params.get(
+                "pbe0_vdw_reference_functional", "PBE0"
+            )
+    else:
+        xc_section.pop("VDW_POTENTIAL", None)
     xc_section["DENSITY_CUTOFF"] = dft_params.get("xc_density_cutoff", 1e-10)
     xc_section["GRADIENT_CUTOFF"] = dft_params.get("xc_gradient_cutoff", 1e-10)
     xc_section["TAU_CUTOFF"] = dft_params.get("xc_tau_cutoff", 1e-10)
@@ -319,7 +434,9 @@ def apply_xc_settings(input_dict, dft_params=None, scf_method="ot"):
         "INTERACTION_POTENTIAL": {
             "POTENTIAL_TYPE": dft_params.get("hfx_potential_type", "TRUNCATED"),
             "CUTOFF_RADIUS": hfx_cutoff_radius,
-            "T_C_G_DATA": dft_params.get("tcg_data_file_name", "t_c_g.dat"),
+            "T_C_G_DATA": _quote_cp2k_file_name(
+                dft_params.get("tcg_data_file_name", "t_c_g.dat")
+            ),
         },
         "MEMORY": {
             "EPS_STORAGE_SCALING": dft_params.get("hfx_eps_storage_scaling", 0.1),

--- a/aiida_nanotech_empa/workflows/cp2k/diag_workchain.py
+++ b/aiida_nanotech_empa/workflows/cp2k/diag_workchain.py
@@ -169,7 +169,8 @@ class Cp2kDiagWorkChain(engine.WorkChain):
 
         if "charge" in self.ctx.dft_params:
             input_dict["FORCE_EVAL"]["DFT"]["CHARGE"] = self.ctx.dft_params["charge"]
-        input_dict["FORCE_EVAL"]["DFT"]["XC"].pop("VDW_POTENTIAL")
+        if not self.ctx.dft_params.get("vdw", False):
+            input_dict["FORCE_EVAL"]["DFT"]["XC"].pop("VDW_POTENTIAL", None)
         cp2k_utils.apply_xc_settings(input_dict, self.ctx.dft_params)
 
         # POISSON_SOLVER

--- a/aiida_nanotech_empa/workflows/cp2k/hrstm_workchain.py
+++ b/aiida_nanotech_empa/workflows/cp2k/hrstm_workchain.py
@@ -126,7 +126,10 @@ class Cp2kHrstmWorkChain(engine.WorkChain):
         inputs["metadata"] = {}
         inputs["metadata"]["label"] = "hrstm"
         inputs["code"] = self.inputs.hrstm_code
-        inputs["parameters"] = self.inputs.hrstm_params
+        hrstm_params = cp2k_utils.update_legacy_basis_parameter(
+            self.inputs.hrstm_params.get_dict(), self.ctx.dft_params
+        )
+        inputs["parameters"] = orm.Dict(hrstm_params)
         inputs["parent_calc_folder"] = self.ctx.diag_scf.outputs.remote_folder
         inputs["ppm_calc_folder"] = self.ctx.ppm.outputs.remote_folder
         inputs["metadata"]["options"] = {

--- a/aiida_nanotech_empa/workflows/cp2k/orbitals_workchain.py
+++ b/aiida_nanotech_empa/workflows/cp2k/orbitals_workchain.py
@@ -2,6 +2,7 @@ import numpy as np
 from aiida import engine, orm, plugins
 
 from ...utils import common_utils
+from . import cp2k_utils
 from .geo_opt_workchain import validate_on_unhandled_failure
 
 Cp2kDiagWorkChain = plugins.WorkflowFactory("nanotech_empa.cp2k.diag")
@@ -110,11 +111,14 @@ class Cp2kOrbitalsWorkChain(engine.WorkChain):
         # Restart wfn.
         if "parent_calc_folder" in self.inputs:
             builder.parent_calc_folder = self.inputs.parent_calc_folder
+        basis_files = cp2k_utils.get_dft_file_names(self.ctx.dft_params)[
+            "basis_set_file_names"
+        ]
         builder.settings = orm.Dict(
             {
                 "additional_retrieve_list": [
                     "aiida.inp",
-                    "BASIS_MOLOPT",
+                    *basis_files,
                     "aiida.coords.xyz",
                     "aiida-RESTART.wfn",
                 ]
@@ -134,7 +138,10 @@ class Cp2kOrbitalsWorkChain(engine.WorkChain):
         inputs["metadata"] = {}
         inputs["metadata"]["label"] = "orb"
         inputs["code"] = self.inputs.spm_code
-        inputs["parameters"] = self.inputs.spm_params
+        spm_params = cp2k_utils.update_legacy_basis_parameter(
+            self.inputs.spm_params.get_dict(), self.ctx.dft_params
+        )
+        inputs["parameters"] = orm.Dict(spm_params)
         inputs["parent_calc_folder"] = self.ctx.diag_scf.outputs.remote_folder
         inputs["metadata"]["options"] = {
             "resources": {

--- a/aiida_nanotech_empa/workflows/cp2k/scf_workchain.py
+++ b/aiida_nanotech_empa/workflows/cp2k/scf_workchain.py
@@ -86,6 +86,12 @@ class Cp2kScfWorkChain(Cp2kDiagWorkChain):
             help="Approximate primitive vectors as rows, separated by semicolons or newlines.",
         )
         spec.input(
+            "unfolding_primitive_basis_atoms",
+            valid_type=orm.Str,
+            required=False,
+            help="1-based atom indices defining the primitive basis, e.g. 1 2 or 171 196.",
+        )
+        spec.input(
             "unfolding_path",
             valid_type=orm.Str,
             default=lambda: orm.Str("G-K-M-G"),
@@ -105,6 +111,20 @@ class Cp2kScfWorkChain(Cp2kDiagWorkChain):
             default=lambda: orm.Float(1.0e-4),
             required=False,
             help="Projection threshold for compact atom-resolved PDOS data attached to unfolding.",
+        )
+        spec.input(
+            "unfolding_basis_cluster_tol",
+            valid_type=orm.Float,
+            default=lambda: orm.Float(5.0e-2),
+            required=False,
+            help="Fallback fractional tolerance used only when primitive basis atoms are omitted.",
+        )
+        spec.input(
+            "unfolding_options",
+            valid_type=orm.Dict,
+            default=lambda: orm.Dict(dict={}),
+            required=False,
+            help="Metadata options for the unfolding post-processing CalcJob.",
         )
         spec.outline(
             cls.setup,
@@ -147,6 +167,11 @@ class Cp2kScfWorkChain(Cp2kDiagWorkChain):
             395,
             "ERROR_MISSING_UNFOLDING_OUTPUT",
             message="CP2K band unfolding finished without retrieving unfolding_bands.npz.",
+        )
+        spec.exit_code(
+            396,
+            "ERROR_MISSING_UNFOLDING_PRIMITIVE_BASIS",
+            message="Primitive basis atom indices are required to compute band unfolding.",
         )
 
     def should_run_diag_scf(self):
@@ -241,30 +266,42 @@ class Cp2kScfWorkChain(Cp2kDiagWorkChain):
             return self.exit_codes.ERROR_MISSING_UNFOLDING_CODE
         if "unfolding_primitive_vectors" not in self.inputs:
             return self.exit_codes.ERROR_MISSING_UNFOLDING_PRIMITIVE_VECTORS
+        if "unfolding_primitive_basis_atoms" not in self.inputs:
+            return self.exit_codes.ERROR_MISSING_UNFOLDING_PRIMITIVE_BASIS
 
         self.report("Running CP2K band unfolding post-processing")
         builder = Cp2kUnfoldingCalculation.get_builder()
         builder.code = self.inputs.unfolding_code
         builder.parent_calc_folder = self.ctx.diag_scf.outputs.remote_folder
         builder.primitive_vectors = self.inputs.unfolding_primitive_vectors
+        builder.primitive_basis_atoms = self.inputs.unfolding_primitive_basis_atoms
         builder.path = self.inputs.unfolding_path
         builder.lattice_type = self.inputs.unfolding_lattice_type
         builder.overlap_threshold = self.inputs.overlap_threshold
+        builder.basis_cluster_tol = self.inputs.unfolding_basis_cluster_tol
         builder.parse_pdos_projections = orm.Bool(True)
         builder.pdos_threshold = self.inputs.unfolding_pdos_threshold
+        unfolding_options = self.inputs.unfolding_options.get_dict()
+        unfolding_options.setdefault(
+            "resources",
+            {
+                "num_machines": 1,
+                "num_mpiprocs_per_machine": 1,
+                "num_cores_per_mpiproc": 1,
+            },
+        )
+        unfolding_options.setdefault(
+            "max_wallclock_seconds",
+            min(7200, self.ctx.options["max_wallclock_seconds"]),
+        )
+        resources = unfolding_options.get("resources", {})
+        nproc = int(resources.get("num_machines", 1)) * int(
+            resources.get("num_mpiprocs_per_machine", 1)
+        )
+        unfolding_options.setdefault("withmpi", nproc > 1)
         builder.metadata = {
             "label": "cp2k_unfolding",
-            "options": {
-                "resources": {
-                    "num_machines": 1,
-                    "num_mpiprocs_per_machine": 1,
-                    "num_cores_per_mpiproc": 1,
-                },
-                "max_wallclock_seconds": min(
-                    7200, self.ctx.options["max_wallclock_seconds"]
-                ),
-                "withmpi": False,
-            },
+            "options": unfolding_options,
         }
         return engine.ToContext(unfolding=self.submit(builder))
 

--- a/aiida_nanotech_empa/workflows/cp2k/stm_workchain.py
+++ b/aiida_nanotech_empa/workflows/cp2k/stm_workchain.py
@@ -2,6 +2,7 @@ import numpy as np
 from aiida import engine, orm, plugins
 
 from ...utils import common_utils
+from . import cp2k_utils
 from .geo_opt_workchain import validate_on_unhandled_failure
 
 Cp2kDiagWorkChain = plugins.WorkflowFactory("nanotech_empa.cp2k.diag")
@@ -117,7 +118,10 @@ class Cp2kStmWorkChain(engine.WorkChain):
         inputs["metadata"] = {}
         inputs["metadata"]["label"] = "stm"
         inputs["code"] = self.inputs.spm_code
-        inputs["parameters"] = self.inputs.spm_params
+        spm_params = cp2k_utils.update_legacy_basis_parameter(
+            self.inputs.spm_params.get_dict(), self.ctx.dft_params
+        )
+        inputs["parameters"] = orm.Dict(spm_params)
         inputs["parent_calc_folder"] = self.ctx.diag_scf.outputs.remote_folder
 
         n_machines = 1


### PR DESCRIPTION
Part of the aiida-nanotech-empa split-PR chain extracted from the full working reference branch feature/cp2k-dft-protocol-refactor. This PR depends on #204 (PR-A9).

Scope:
- carry flexible DFT file/basis settings through STM, HRSTM, orbitals, and related CP2K post-processing workflows;
- update legacy BASIS_MOLOPT command-line defaults only when the active DFT basis file differs;
- add primitive-basis-atom and tolerance inputs to CP2K unfolding;
- allow unfolding metadata/options and infer MPI use from requested resources.

Files touched:
- aiida_nanotech_empa/plugins/unfolding.py
- aiida_nanotech_empa/workflows/cp2k/cp2k_utils.py
- aiida_nanotech_empa/workflows/cp2k/diag_workchain.py
- aiida_nanotech_empa/workflows/cp2k/hrstm_workchain.py
- aiida_nanotech_empa/workflows/cp2k/orbitals_workchain.py
- aiida_nanotech_empa/workflows/cp2k/scf_workchain.py
- aiida_nanotech_empa/workflows/cp2k/stm_workchain.py

Validation:
- python -m py_compile on all touched Python files
- compared patch against commit a669209 from the full reference history.