### PR TITLE
PR-A11: Use valid CP2K parser output exit codes

### DIFF
--- a/aiida_nanotech_empa/parsers/cp2k_gw_parser.py
+++ b/aiida_nanotech_empa/parsers/cp2k_gw_parser.py
@@ -36,7 +36,7 @@ class Cp2kGwParser(Cp2kBaseParser):
         try:
             output_string = self.retrieved.base.repository.get_object_content(fname)
         except OSError:
-            return self.exit_codes.ERROR_OUTPUT_STDOUT_READ
+            return self.exit_codes.ERROR_OUTPUT_READ
 
         # CP2K advanced parsing provided by aiida-cp2k
         result_dict = parse_cp2k_output_advanced(output_string)

--- a/aiida_nanotech_empa/parsers/cp2k_neb_parser.py
+++ b/aiida_nanotech_empa/parsers/cp2k_neb_parser.py
@@ -35,12 +35,12 @@ class Cp2kNebParser(parsers.Parser):
         fname = self.node.process_class._DEFAULT_OUTPUT_FILE
 
         if fname not in self.retrieved.list_object_names():
-            return self.exit_codes.ERROR_OUTPUT_STDOUT_MISSING
+            return self.exit_codes.ERROR_OUTPUT_MISSING
 
         try:
             output_string = self.retrieved.get_object_content(fname)
         except OSError:
-            return self.exit_codes.ERROR_OUTPUT_STDOUT_READ
+            return self.exit_codes.ERROR_OUTPUT_READ
 
         """Parse CP2K output into a dictionary."""
         lines = output_string.splitlines()
@@ -99,7 +99,7 @@ class Cp2kNebParser(parsers.Parser):
         try:
             output_string = self.retrieved.get_object_content(fname)
         except OSError:
-            return self.exit_codes.ERROR_OUTPUT_STDOUT_READ
+            return self.exit_codes.ERROR_OUTPUT_READ
 
         m = re.search(r"\n\s*&CELL\n(.*?)\n\s*&END CELL\n", output_string, re.DOTALL)
         cell_lines = [line.strip().split() for line in m.group(1).split("\n")]


### PR DESCRIPTION
Part of the aiida-nanotech-empa split-PR chain extracted from the full working reference branch feature/cp2k-dft-protocol-refactor. This PR depends on #205 (PR-A10).

Scope:
- replace invalid ERROR_OUTPUT_STDOUT_MISSING/READ references with valid parser exit codes;
- avoid AttributeError masking the real missing-output/read failure in GW and NEB parsers.

Files touched:
- aiida_nanotech_empa/parsers/cp2k_gw_parser.py
- aiida_nanotech_empa/parsers/cp2k_neb_parser.py

Validation:
- python -m py_compile on both parser files
- extracted from the parser part of commit 206569f from the full reference history.