### PR TITLE
PR-A12: Request Lowdin charge output

### DIFF
--- a/aiida_nanotech_empa/workflows/cp2k/cp2k_utils.py
+++ b/aiida_nanotech_empa/workflows/cp2k/cp2k_utils.py
@@ -366,6 +366,13 @@ def _pbe0_scf_section(dft_params, old_scf):
     return scf_section
 
 
+def apply_default_charge_analysis(input_dict):
+    """Request default CP2K charge analyses for standard SCF/geopt workflows."""
+
+    print_section = input_dict["FORCE_EVAL"]["DFT"].setdefault("PRINT", {})
+    print_section["LOWDIN"] = {"PRINT_GOP": "T"}
+
+
 def apply_xc_settings(input_dict, dft_params=None, scf_method="ot"):
     """Apply XC/SCF settings while preserving legacy PBE inputs by default."""
 

--- a/aiida_nanotech_empa/workflows/cp2k/geo_opt_workchain.py
+++ b/aiida_nanotech_empa/workflows/cp2k/geo_opt_workchain.py
@@ -115,6 +115,7 @@ class Cp2kGeoOptWorkChain(engine.WorkChain):
             self.ctx.input_dict["FORCE_EVAL"]["DFT"]["XC"].pop("VDW_POTENTIAL")
 
         cp2k_utils.apply_xc_settings(self.ctx.input_dict, self.ctx.dft_params)
+        cp2k_utils.apply_default_charge_analysis(self.ctx.input_dict)
 
         # Charge.
         if "charge" in self.ctx.dft_params:

--- a/aiida_nanotech_empa/workflows/cp2k/scf_workchain.py
+++ b/aiida_nanotech_empa/workflows/cp2k/scf_workchain.py
@@ -1,6 +1,7 @@
 from aiida import engine, orm, plugins
 
 from ...utils import common_utils
+from . import cp2k_utils
 from .diag_workchain import Cp2kDiagWorkChain
 
 BaderCalculation = plugins.CalculationFactory("nanotech_empa.bader")
@@ -196,6 +197,7 @@ class Cp2kScfWorkChain(Cp2kDiagWorkChain):
         return self.inputs.compute_unfolding.value
 
     def update_ot_input_dict(self, input_dict):
+        cp2k_utils.apply_default_charge_analysis(input_dict)
         if not self.should_run_bader():
             return
 


### PR DESCRIPTION
Part of the aiida-nanotech-empa split-PR chain extracted from the full working reference branch feature/cp2k-dft-protocol-refactor. This PR depends on #206 (PR-A11).

Scope:
- add a helper to request CP2K Lowdin population analysis under DFT/PRINT;
- enable the default Lowdin output for standard geometry optimization and SCF OT steps;
- keep Bader, PDOS, SPM, and other specialized workflows unchanged.

Files touched:
- aiida_nanotech_empa/workflows/cp2k/cp2k_utils.py
- aiida_nanotech_empa/workflows/cp2k/geo_opt_workchain.py
- aiida_nanotech_empa/workflows/cp2k/scf_workchain.py

Validation:
- python -m py_compile on cp2k_utils.py, geo_opt_workchain.py, and scf_workchain.py
- verified this stacked branch has no remaining diff against feature/cp2k-dft-protocol-refactor.