### PR TITLE
Add QE BandUPpy unfolding workflow

### DIFF
--- a/aiida_nanotech_empa/plugins/__init__.py
+++ b/aiida_nanotech_empa/plugins/__init__.py
@@ -2,6 +2,7 @@ from .afm import AfmCalculation
 from .cubehandler import CubeHandlerCalculation
 from .hrstm import HrstmCalculation
 from .overlap import OverlapCalculation
+from .qe_banduppy import QeBanduppyCalculation
 from .stm import StmCalculation
 
 __all__ = (
@@ -9,5 +10,6 @@ __all__ = (
     "CubeHandlerCalculation",
     "HrstmCalculation",
     "OverlapCalculation",
+    "QeBanduppyCalculation",
     "StmCalculation",
 )

--- a/aiida_nanotech_empa/plugins/qe_banduppy.py
+++ b/aiida_nanotech_empa/plugins/qe_banduppy.py
@@ -1,0 +1,217 @@
+import json
+import textwrap
+
+import numpy as np
+from aiida import common, engine, orm
+
+
+DEFAULT_INPUT_NPZ = "banduppy_inputs.npz"
+DEFAULT_SETTINGS_JSON = "banduppy_settings.json"
+DEFAULT_RUN_SCRIPT = "run_banduppy_qe.py"
+DEFAULT_OUTPUT_NPZ = "unfolding_bands.npz"
+
+
+class QeBanduppyCalculation(engine.CalcJob):
+    """Run BandUPpy on a Quantum ESPRESSO bands calculation remote folder."""
+
+    @classmethod
+    def define(cls, spec):
+        super().define(spec)
+        spec.input(
+            "folded_qe_remote_folder",
+            valid_type=orm.RemoteData,
+            help="Remote folder of the QE bands calculation on folded supercell k-points.",
+        )
+        spec.input("parameters", valid_type=orm.Dict)
+        spec.input("mapping_arrays", valid_type=orm.ArrayData)
+        spec.input("mapping_data", valid_type=orm.Dict)
+        spec.input("special_labels", valid_type=orm.Dict)
+        spec.input(
+            "settings",
+            valid_type=orm.Dict,
+            default=lambda: orm.Dict(dict={}),
+            required=False,
+        )
+        spec.input("metadata.options.withmpi", valid_type=bool, default=False)
+
+    def prepare_for_submission(self, folder):
+        settings = self.inputs.settings.get_dict() if "settings" in self.inputs else {}
+        parameters = self.inputs.parameters.get_dict()
+
+        with folder.open(DEFAULT_SETTINGS_JSON, "w") as handle:
+            json.dump(
+                {
+                    "parameters": parameters,
+                    "mapping_data": self.inputs.mapping_data.get_dict(),
+                    "special_labels": self.inputs.special_labels.get_dict(),
+                    "output_npz": parameters.get("output_npz", DEFAULT_OUTPUT_NPZ),
+                },
+                handle,
+            )
+
+        arrays = self.inputs.mapping_arrays
+        npz_arrays = {
+            "kpoints_pbz_full": arrays.get_array("kpoints_pbz_full"),
+            "kpoints_sbz": arrays.get_array("kpoints_sbz"),
+            "supercell_matrix": arrays.get_array("supercell_matrix"),
+        }
+        if "primitive_kline" in arrays.get_arraynames():
+            npz_arrays["primitive_kline"] = arrays.get_array("primitive_kline")
+        with folder.open(DEFAULT_INPUT_NPZ, "wb") as handle:
+            np.savez(handle, **npz_arrays)
+
+        with folder.open(DEFAULT_RUN_SCRIPT, "w") as handle:
+            handle.write(_runner_script())
+
+        codeinfo = common.CodeInfo()
+        codeinfo.code_uuid = self.inputs.code.uuid
+        codeinfo.cmdline_params = [DEFAULT_RUN_SCRIPT]
+
+        calcinfo = common.CalcInfo()
+        calcinfo.uuid = self.uuid
+        calcinfo.codes_info = [codeinfo]
+        calcinfo.remote_symlink_list = []
+        calcinfo.remote_copy_list = []
+        calcinfo.local_copy_list = []
+
+        output_npz = parameters.get("output_npz", DEFAULT_OUTPUT_NPZ)
+        calcinfo.retrieve_list = settings.pop(
+            "additional_retrieve_list",
+            [
+                output_npz,
+                "banduppy_stdout.txt",
+            ],
+        )
+
+        comp_uuid = self.inputs.folded_qe_remote_folder.computer.uuid
+        remote_path = self.inputs.folded_qe_remote_folder.get_remote_path()
+        copy_info = (comp_uuid, remote_path, "folded_qe_remote/")
+        if self.inputs.code.computer.uuid == comp_uuid:
+            calcinfo.remote_symlink_list.append(copy_info)
+        else:
+            calcinfo.remote_copy_list.append(copy_info)
+
+        if settings:
+            raise common.InputValidationError(
+                "The following keys have been found in settings but were not understood: "
+                + ",".join(settings.keys())
+            )
+
+        return calcinfo
+
+
+def _runner_script():
+    return textwrap.dedent(
+        r'''
+        import contextlib
+        import json
+        from pathlib import Path
+
+        import numpy as np
+
+        import banduppy
+
+
+        def _restore_int_mapping(mapping):
+            return {
+                int(k_index): {
+                    int(unique_index): [int(item) for item in k_indices]
+                    for unique_index, k_indices in unique_map.items()
+                }
+                for k_index, unique_map in mapping.items()
+            }
+
+
+        with open("banduppy_settings.json", "r") as handle:
+            settings = json.load(handle)
+        params = settings["parameters"]
+        special_labels = settings["special_labels"]
+        sbz_pbz_mapping = _restore_int_mapping(settings["mapping_data"])
+        output_npz = settings["output_npz"]
+
+        arrays = np.load("banduppy_inputs.npz", allow_pickle=True)
+        supercell_matrix = np.asarray(arrays["supercell_matrix"], dtype=int)
+        kpoints_pbz_full = arrays["kpoints_pbz_full"]
+        kpoints_sbz = arrays["kpoints_sbz"]
+        primitive_kline = arrays["primitive_kline"] if "primitive_kline" in arrays.files else None
+
+        prefix = params.get("prefix", "aiida")
+        outdir = params.get("outdir", "./out/")
+        spinor = params.get("spinor")
+        spin_channels = params.get("spin_channels")
+        if spin_channels is None:
+            spin_channel = params.get("spin_channel")
+            spin_channels = [spin_channel] if spin_channel is not None else [None]
+        spin_channels = [None if channel in (None, "", "none") else str(channel) for channel in spin_channels]
+        discontinuity = float(params.get("kline_discontinuity_threshold", 0.1))
+        fermi_energy = params.get("fermi_energy")
+
+        qe_base = Path("folded_qe_remote")
+        prefix_path = Path(outdir)
+        if not prefix_path.is_absolute():
+            prefix_path = qe_base / prefix_path
+        prefix_path = prefix_path / prefix
+        save_dir = Path(str(prefix_path) + ".save")
+        if not save_dir.exists():
+            raise FileNotFoundError(f"Cannot find QE .save directory: {save_dir}")
+
+        unfolded_by_channel = {}
+        kline = None
+        with open("banduppy_stdout.txt", "w") as stdout, contextlib.redirect_stdout(stdout):
+            for channel in spin_channels:
+                suffix = "" if channel is None else f"_{channel}"
+                band_unfold = banduppy.Unfolding(supercell=supercell_matrix, print_log=None)
+                bands = banduppy.BandStructure(
+                    code="espresso",
+                    spinor=spinor,
+                    spin_channel=channel,
+                    prefix=str(prefix_path),
+                )
+                unfolded, channel_kline = band_unfold.Unfold(
+                    bands,
+                    PBZ_kpts_list_full=kpoints_pbz_full,
+                    SBZ_kpts_list=kpoints_sbz,
+                    SBZ_PBZ_kpts_map=sbz_pbz_mapping,
+                    kline_discontinuity_threshold=discontinuity,
+                    save_unfolded_kpts={
+                        "save2file": True,
+                        "fdir": ".",
+                        "fname": "kpoints_unfolded",
+                        "fname_suffix": suffix,
+                    },
+                    save_unfolded_bandstr={
+                        "save2file": True,
+                        "fdir": ".",
+                        "fname": "bandstructure_unfolded",
+                        "fname_suffix": suffix,
+                    },
+                )
+                if primitive_kline is not None:
+                    indices = np.rint(unfolded[:, 0]).astype(int)
+                    valid = (indices >= 0) & (indices < len(primitive_kline))
+                    unfolded = unfolded.copy()
+                    unfolded[valid, 1] = primitive_kline[indices[valid]]
+                unfolded_by_channel["none" if channel is None else channel] = unfolded
+                if kline is None:
+                    kline = channel_kline
+
+        first_channel = next(iter(unfolded_by_channel))
+        output_arrays = {
+            "unfolded_bandstructure": unfolded_by_channel[first_channel],
+            "kline": kline,
+            "special_labels": json.dumps(special_labels),
+            "supercell_matrix": supercell_matrix,
+            "kpoints_pbz_full": kpoints_pbz_full,
+            "kpoints_sbz": kpoints_sbz,
+            "fermi_energy": np.nan if fermi_energy is None else float(fermi_energy),
+            "prefix_path": str(prefix_path),
+            "spin_channels": np.asarray(list(unfolded_by_channel.keys()), dtype=str),
+        }
+        for channel, unfolded in unfolded_by_channel.items():
+            output_arrays[f"unfolded_bandstructure_{channel}"] = unfolded
+        if primitive_kline is not None:
+            output_arrays["primitive_kline"] = primitive_kline
+
+        np.savez(output_npz, **output_arrays)
+        '''
+    ).lstrip()

--- a/aiida_nanotech_empa/plugins/qe_banduppy.py
+++ b/aiida_nanotech_empa/plugins/qe_banduppy.py
@@ -4,7 +4,6 @@ import textwrap
 import numpy as np
 from aiida import common, engine, orm
 
-
 DEFAULT_INPUT_NPZ = "banduppy_inputs.npz"
 DEFAULT_SETTINGS_JSON = "banduppy_settings.json"
 DEFAULT_RUN_SCRIPT = "run_banduppy_qe.py"
@@ -102,7 +101,7 @@ class QeBanduppyCalculation(engine.CalcJob):
 
 def _runner_script():
     return textwrap.dedent(
-        r'''
+        r"""
         import contextlib
         import json
         from pathlib import Path
@@ -213,5 +212,5 @@ def _runner_script():
             output_arrays["primitive_kline"] = primitive_kline
 
         np.savez(output_npz, **output_arrays)
-        '''
+        """
     ).lstrip()

--- a/aiida_nanotech_empa/plugins/qe_banduppy.py
+++ b/aiida_nanotech_empa/plugins/qe_banduppy.py
@@ -104,6 +104,9 @@ def _runner_script():
         r"""
         import contextlib
         import json
+        import os
+        import subprocess
+        import sys
         from pathlib import Path
 
         import numpy as np
@@ -121,96 +124,353 @@ def _runner_script():
             }
 
 
-        with open("banduppy_settings.json", "r") as handle:
-            settings = json.load(handle)
-        params = settings["parameters"]
-        special_labels = settings["special_labels"]
-        sbz_pbz_mapping = _restore_int_mapping(settings["mapping_data"])
-        output_npz = settings["output_npz"]
+        def _load_inputs():
+            with open("banduppy_settings.json", "r") as handle:
+                settings = json.load(handle)
+            params = settings["parameters"]
+            arrays = np.load("banduppy_inputs.npz", allow_pickle=True)
+            primitive_kline = (
+                arrays["primitive_kline"] if "primitive_kline" in arrays.files else None
+            )
+            return {
+                "params": params,
+                "special_labels": settings["special_labels"],
+                "mapping": _restore_int_mapping(settings["mapping_data"]),
+                "output_npz": settings["output_npz"],
+                "supercell_matrix": np.asarray(arrays["supercell_matrix"], dtype=int),
+                "kpoints_pbz_full": arrays["kpoints_pbz_full"],
+                "kpoints_sbz": arrays["kpoints_sbz"],
+                "primitive_kline": primitive_kline,
+            }
 
-        arrays = np.load("banduppy_inputs.npz", allow_pickle=True)
-        supercell_matrix = np.asarray(arrays["supercell_matrix"], dtype=int)
-        kpoints_pbz_full = arrays["kpoints_pbz_full"]
-        kpoints_sbz = arrays["kpoints_sbz"]
-        primitive_kline = arrays["primitive_kline"] if "primitive_kline" in arrays.files else None
 
-        prefix = params.get("prefix", "aiida")
-        outdir = params.get("outdir", "./out/")
-        spinor = params.get("spinor")
-        spin_channels = params.get("spin_channels")
-        if spin_channels is None:
-            spin_channel = params.get("spin_channel")
-            spin_channels = [spin_channel] if spin_channel is not None else [None]
-        spin_channels = [None if channel in (None, "", "none") else str(channel) for channel in spin_channels]
-        discontinuity = float(params.get("kline_discontinuity_threshold", 0.1))
-        fermi_energy = params.get("fermi_energy")
+        def _spin_channels(params):
+            spin_channels = params.get("spin_channels")
+            if spin_channels is None:
+                spin_channel = params.get("spin_channel")
+                spin_channels = [spin_channel] if spin_channel is not None else [None]
+            return [
+                None if channel in (None, "", "none") else str(channel)
+                for channel in spin_channels
+            ]
 
-        qe_base = Path("folded_qe_remote")
-        prefix_path = Path(outdir)
-        if not prefix_path.is_absolute():
-            prefix_path = qe_base / prefix_path
-        prefix_path = prefix_path / prefix
-        save_dir = Path(str(prefix_path) + ".save")
-        if not save_dir.exists():
-            raise FileNotFoundError(f"Cannot find QE .save directory: {save_dir}")
 
-        unfolded_by_channel = {}
-        kline = None
-        with open("banduppy_stdout.txt", "w") as stdout, contextlib.redirect_stdout(stdout):
-            for channel in spin_channels:
-                suffix = "" if channel is None else f"_{channel}"
-                band_unfold = banduppy.Unfolding(supercell=supercell_matrix, print_log=None)
-                bands = banduppy.BandStructure(
-                    code="espresso",
-                    spinor=spinor,
-                    spin_channel=channel,
-                    prefix=str(prefix_path),
+        def _channel_key(channel):
+            return "none" if channel is None else str(channel)
+
+
+        def _channel_from_key(channel_key):
+            return None if channel_key == "none" else channel_key
+
+
+        def _band_slice(params):
+            ib_start = params.get("ib_start", params.get("IBstart"))
+            ib_end = params.get("ib_end", params.get("IBend"))
+            ib_start = None if ib_start in (None, "") else int(ib_start)
+            ib_end = None if ib_end in (None, "") else int(ib_end)
+            return ib_start, ib_end
+
+
+        def _prefix_path(params):
+            prefix = params.get("prefix", "aiida")
+            outdir = params.get("outdir", "./out/")
+            qe_base = Path("folded_qe_remote")
+            prefix_path = Path(outdir)
+            if not prefix_path.is_absolute():
+                prefix_path = qe_base / prefix_path
+            prefix_path = prefix_path / prefix
+            save_dir = Path(str(prefix_path) + ".save")
+            if not save_dir.exists():
+                raise FileNotFoundError(f"Cannot find QE .save directory: {save_dir}")
+            return prefix_path
+
+
+        def _batches(items, batch_size):
+            for start in range(0, len(items), batch_size):
+                yield items[start:start + batch_size]
+
+
+        def _local_batch_inputs(full_mapping, batch_indices, full_pbz_kpoints):
+            global_pbz_indices = sorted(
+                {
+                    int(index)
+                    for k_index in batch_indices
+                    for index_group in full_mapping[int(k_index)].values()
+                    for index in index_group
+                }
+            )
+            local_to_global = np.asarray(global_pbz_indices, dtype=int)
+            global_to_local = {
+                int(global_index): local_index
+                for local_index, global_index in enumerate(local_to_global)
+            }
+            local_mapping = {}
+            for k_index in batch_indices:
+                local_mapping[int(k_index)] = {
+                    local_unique_index: [
+                        global_to_local[int(global_index)]
+                        for global_index in global_indices
+                    ]
+                    for local_unique_index, global_indices in enumerate(
+                        full_mapping[int(k_index)].values()
+                    )
+                }
+            return full_pbz_kpoints[local_to_global], local_mapping, local_to_global
+
+
+        def _restore_global_kline(unfolded, local_to_global, primitive_kline):
+            if unfolded.size == 0:
+                return unfolded
+            local_indices = np.rint(unfolded[:, 0]).astype(int)
+            valid = (local_indices >= 0) & (local_indices < len(local_to_global))
+            unfolded = unfolded.copy()
+            unfolded[valid, 0] = local_to_global[local_indices[valid]]
+            if primitive_kline is not None:
+                global_indices = np.rint(unfolded[:, 0]).astype(int)
+                valid = (global_indices >= 0) & (global_indices < len(primitive_kline))
+                unfolded[valid, 1] = primitive_kline[global_indices[valid]]
+            return unfolded
+
+
+        def _sort_unfolded_rows(unfolded):
+            if unfolded.size == 0:
+                return unfolded
+            return unfolded[np.lexsort((unfolded[:, 2], unfolded[:, 0]))]
+
+
+        def _patch_espresso_hdf5_band_slice(ib_start, ib_end):
+            if ib_start is None and ib_end is None:
+                return False
+
+            import h5py
+            from irrep import readfiles as ir_readfiles
+
+            original_parse_header = ir_readfiles.ParserEspresso.parse_header
+            original_parse_kpoint = ir_readfiles.ParserEspresso.parse_kpoint
+
+            def _normalized_slice(nbands):
+                start = 0 if ib_start is None else int(ib_start)
+                stop = nbands if ib_end is None else int(ib_end)
+                if start < 0:
+                    start = nbands + start
+                if stop <= 0:
+                    stop = nbands + stop
+                if start < 0 or stop > nbands or start >= stop:
+                    raise RuntimeError(
+                        f"Invalid band slice [{start}, {stop}) for {nbands} bands"
+                    )
+                return start, stop
+
+            def parse_header(self, spin_channel=None):
+                spinpol, ecut0, ef, nkpoints, nbands = original_parse_header(
+                    self, spin_channel=spin_channel
                 )
-                unfolded, channel_kline = band_unfold.Unfold(
-                    bands,
-                    PBZ_kpts_list_full=kpoints_pbz_full,
-                    SBZ_kpts_list=kpoints_sbz,
-                    SBZ_PBZ_kpts_map=sbz_pbz_mapping,
-                    kline_discontinuity_threshold=discontinuity,
-                    save_unfolded_kpts={
-                        "save2file": True,
-                        "fdir": ".",
-                        "fname": "kpoints_unfolded",
-                        "fname_suffix": suffix,
-                    },
-                    save_unfolded_bandstr={
-                        "save2file": True,
-                        "fdir": ".",
-                        "fname": "bandstructure_unfolded",
-                        "fname_suffix": suffix,
-                    },
+                start, stop = _normalized_slice(nbands)
+                self._aiida_band_slice = (start, stop, nbands)
+                print(
+                    "Reading QE HDF5 wavefunctions with band slice "
+                    f"[{start}, {stop}) out of {nbands} bands",
+                    flush=True,
                 )
-                if primitive_kline is not None:
-                    indices = np.rint(unfolded[:, 0]).astype(int)
-                    valid = (indices >= 0) & (indices < len(primitive_kline))
-                    unfolded = unfolded.copy()
-                    unfolded[valid, 1] = primitive_kline[indices[valid]]
-                unfolded_by_channel["none" if channel is None else channel] = unfolded
-                if kline is None:
-                    kline = channel_kline
+                return spinpol, ecut0, ef, nkpoints, stop - start
 
-        first_channel = next(iter(unfolded_by_channel))
-        output_arrays = {
-            "unfolded_bandstructure": unfolded_by_channel[first_channel],
-            "kline": kline,
-            "special_labels": json.dumps(special_labels),
-            "supercell_matrix": supercell_matrix,
-            "kpoints_pbz_full": kpoints_pbz_full,
-            "kpoints_sbz": kpoints_sbz,
-            "fermi_energy": np.nan if fermi_energy is None else float(fermi_energy),
-            "prefix_path": str(prefix_path),
-            "spin_channels": np.asarray(list(unfolded_by_channel.keys()), dtype=str),
-        }
-        for channel, unfolded in unfolded_by_channel.items():
-            output_arrays[f"unfolded_bandstructure_{channel}"] = unfolded
-        if primitive_kline is not None:
-            output_arrays["primitive_kline"] = primitive_kline
+            def parse_kpoint(self, ik, verbosity=0):
+                band_slice = getattr(self, "_aiida_band_slice", None)
+                if band_slice is None:
+                    return original_parse_kpoint(self, ik, verbosity=verbosity)
 
-        np.savez(output_npz, **output_arrays)
+                kptxml = self.bandstr.findall("ks_energies")[ik]
+                if self.spinpol:
+                    if self.spin_channel == "up":
+                        nb_skip = 0
+                        nbands = self.NBin_list[0]
+                    else:
+                        nb_skip = self.NBin_list[0]
+                        nbands = self.NBin_list[1]
+                else:
+                    nb_skip = 0
+                    nbands = self.NBin_list[0]
+
+                start, stop, original_nbands = band_slice
+                if nbands != original_nbands:
+                    raise RuntimeError(
+                        "Band-slice parser saw inconsistent QE band counts: "
+                        f"header={original_nbands}, k-point={nbands}"
+                    )
+
+                energy_values = np.array(
+                    kptxml.find("eigenvalues").text.split(), dtype=float
+                )
+                energy = energy_values[nb_skip + start:nb_skip + stop]
+                energy *= ir_readfiles.Hartree_eV
+                npw = int(kptxml.find("npw").text)
+                nspinor = 2 if self.spinor else 1
+
+                wfcname = f"wfc{'' if self.spin_channel is None else self.spin_channel}{ik + 1}"
+                checked_files = []
+                for extension in ["hdf5", "dat"]:
+                    for strcase in [str.lower, str.upper]:
+                        filename = f"{self.prefix}.save/{strcase(wfcname)}.{extension}"
+                        if not os.path.exists(filename):
+                            checked_files.append(filename)
+                            continue
+                        if extension != "hdf5":
+                            raise RuntimeError(
+                                "Band-sliced QE parsing is implemented for HDF5 "
+                                f"wavefunction files only, got {filename}"
+                            )
+                        with h5py.File(filename, "r") as handle:
+                            xk = handle.attrs["xk"]
+                            kpt = np.array(xk)
+                            miller_indices = handle["MillerIndices"]
+                            b_matrix = np.array(
+                                [miller_indices.attrs[f"bg{i}"] for i in range(1, 4)]
+                            )
+                            kg = np.array(miller_indices[::])
+                            kpt = kpt.dot(np.linalg.inv(b_matrix))
+                            evc = np.asarray(handle["evc"][start:stop, :], dtype=float)
+                        wf = evc[:, 0::2] + 1.0j * evc[:, 1::2]
+                        wf = wf.reshape((stop - start, npw, nspinor), order="F")
+                        return wf, energy, kg, kpt
+                raise RuntimeError(f"Wavefunction file not found. Tried files: {checked_files}")
+
+            ir_readfiles.ParserEspresso.parse_header = parse_header
+            ir_readfiles.ParserEspresso.parse_kpoint = parse_kpoint
+            return True
+
+
+        def _run_batch_worker(channel_key, batch_indices_text, output_file):
+            data = _load_inputs()
+            params = data["params"]
+            channel = _channel_from_key(channel_key)
+            batch_indices = [int(item) for item in batch_indices_text.split(",") if item]
+            ib_start, ib_end = _band_slice(params)
+            slice_parser_bands = _patch_espresso_hdf5_band_slice(ib_start, ib_end)
+            bandstructure_ib_start = None if slice_parser_bands else ib_start
+            bandstructure_ib_end = None if slice_parser_bands else ib_end
+            local_pbz, local_mapping, local_to_global = _local_batch_inputs(
+                data["mapping"], batch_indices, data["kpoints_pbz_full"]
+            )
+            band_unfold = banduppy.Unfolding(
+                supercell=data["supercell_matrix"], print_log=None
+            )
+            bands = banduppy.BandStructure(
+                code="espresso",
+                spinor=params.get("spinor"),
+                spin_channel=channel,
+                prefix=str(_prefix_path(params)),
+                kplist=batch_indices,
+                IBstart=bandstructure_ib_start,
+                IBend=bandstructure_ib_end,
+            )
+            unfolded, _ = band_unfold.Unfold(
+                bands,
+                PBZ_kpts_list_full=local_pbz,
+                SBZ_kpts_list=data["kpoints_sbz"],
+                SBZ_PBZ_kpts_map=local_mapping,
+                kline_discontinuity_threshold=float(
+                    params.get("kline_discontinuity_threshold", 0.1)
+                ),
+                save_unfolded_kpts={"save2file": False},
+                save_unfolded_bandstr={"save2file": False},
+            )
+            unfolded = _restore_global_kline(
+                unfolded, local_to_global, data["primitive_kline"]
+            )
+            np.savez(output_file, unfolded=unfolded)
+
+
+        def _run_batch_subprocess(channel_key, batch_number, batch_indices):
+            output_file = f"banduppy_batch_{channel_key}_{batch_number:04d}.npz"
+            cmdline = [
+                sys.executable,
+                str(Path(__file__).resolve()),
+                "--batch-worker",
+                channel_key,
+                ",".join(str(index) for index in batch_indices),
+                output_file,
+            ]
+            subprocess.run(cmdline, check=True)
+            with np.load(output_file, allow_pickle=True) as batch_data:
+                unfolded = np.asarray(batch_data["unfolded"])
+            Path(output_file).unlink(missing_ok=True)
+            return unfolded
+
+
+        def main():
+            data = _load_inputs()
+            params = data["params"]
+            _prefix_path(params)
+            spin_channels = _spin_channels(params)
+            kpoint_batch_size = max(1, int(params.get("kpoint_batch_size", 1)))
+            fermi_energy = params.get("fermi_energy")
+            ib_start, ib_end = _band_slice(params)
+            sbz_indices = sorted(int(index) for index in data["mapping"])
+            unfolded_by_channel = {}
+            kline = None
+
+            with open("banduppy_stdout.txt", "w", buffering=1) as stdout, contextlib.redirect_stdout(stdout):
+                print(f"BandUPpy k-point batch size: {kpoint_batch_size}")
+                print(f"Folded supercell k-points: {len(sbz_indices)}")
+                print(f"Band slice: [{ib_start}, {ib_end})")
+                for channel in spin_channels:
+                    channel_key = _channel_key(channel)
+                    channel_parts = []
+                    print(f"Spin channel {channel_key}: starting subprocess batches")
+                    for batch_number, batch_indices in enumerate(
+                        _batches(sbz_indices, kpoint_batch_size), start=1
+                    ):
+                        print(
+                            "  batch "
+                            f"{batch_number}: folded k-point indices {batch_indices}",
+                            flush=True,
+                        )
+                        channel_parts.append(
+                            _run_batch_subprocess(
+                                channel_key, batch_number, batch_indices
+                            )
+                        )
+                    unfolded = (
+                        np.concatenate(channel_parts, axis=0)
+                        if channel_parts
+                        else np.empty((0, 4))
+                    )
+                    unfolded = _sort_unfolded_rows(unfolded)
+                    unfolded_by_channel[channel_key] = unfolded
+                    if kline is None:
+                        kline = (
+                            data["primitive_kline"]
+                            if data["primitive_kline"] is not None
+                            else np.unique(unfolded[:, 1])
+                        )
+
+            first_channel = next(iter(unfolded_by_channel))
+            output_arrays = {
+                "unfolded_bandstructure": unfolded_by_channel[first_channel],
+                "kline": kline,
+                "special_labels": json.dumps(data["special_labels"]),
+                "supercell_matrix": data["supercell_matrix"],
+                "kpoints_pbz_full": data["kpoints_pbz_full"],
+                "kpoints_sbz": data["kpoints_sbz"],
+                "fermi_energy": np.nan if fermi_energy is None else float(fermi_energy),
+                "prefix_path": str(_prefix_path(params)),
+                "spin_channels": np.asarray(list(unfolded_by_channel.keys()), dtype=str),
+                "kpoint_batch_size": np.asarray(kpoint_batch_size, dtype=int),
+                "ib_start": np.asarray(-1 if ib_start is None else ib_start, dtype=int),
+                "ib_end": np.asarray(-1 if ib_end is None else ib_end, dtype=int),
+            }
+            for channel, unfolded in unfolded_by_channel.items():
+                output_arrays[f"unfolded_bandstructure_{channel}"] = unfolded
+            if data["primitive_kline"] is not None:
+                output_arrays["primitive_kline"] = data["primitive_kline"]
+
+            np.savez(data["output_npz"], **output_arrays)
+
+
+        if __name__ == "__main__":
+            if len(sys.argv) > 1 and sys.argv[1] == "--batch-worker":
+                _run_batch_worker(sys.argv[2], sys.argv[3], sys.argv[4])
+            else:
+                main()
         """
     ).lstrip()

--- a/aiida_nanotech_empa/workflows/cp2k/adsorbed_gw_ic_workchain.py
+++ b/aiida_nanotech_empa/workflows/cp2k/adsorbed_gw_ic_workchain.py
@@ -2,8 +2,8 @@ import numpy as np
 from aiida import engine, orm
 
 from .geo_opt_workchain import Cp2kGeoOptWorkChain
-from .molecule_gw_workchain import Cp2kMoleculeGwWorkChain
 from .molecule_opt_gw_workchain import geo_opt_dft_params
+from .molecule_gw_workchain import Cp2kMoleculeGwWorkChain
 
 IC_PLANE_HEIGHTS = {
     "Au(111)": 1.42,  # Kharche J. Phys. Chem. Lett. 7, 1526–1533 (2016).

--- a/aiida_nanotech_empa/workflows/cp2k/adsorbed_gw_ic_workchain.py
+++ b/aiida_nanotech_empa/workflows/cp2k/adsorbed_gw_ic_workchain.py
@@ -2,8 +2,8 @@ import numpy as np
 from aiida import engine, orm
 
 from .geo_opt_workchain import Cp2kGeoOptWorkChain
-from .molecule_opt_gw_workchain import geo_opt_dft_params
 from .molecule_gw_workchain import Cp2kMoleculeGwWorkChain
+from .molecule_opt_gw_workchain import geo_opt_dft_params
 
 IC_PLANE_HEIGHTS = {
     "Au(111)": 1.42,  # Kharche J. Phys. Chem. Lett. 7, 1526–1533 (2016).

--- a/aiida_nanotech_empa/workflows/cp2k/cp2k_utils.py
+++ b/aiida_nanotech_empa/workflows/cp2k/cp2k_utils.py
@@ -560,7 +560,7 @@ def string_range_to_list(strng, shift=-1):
             return [], False
 
         if ".." in item:
-            start, end = [int(value) for value in item.split("..")]
+            start, end = (int(value) for value in item.split(".."))
             if start > end:
                 return [], False
             indexes.extend(i + shift for i in range(start, end + 1))
@@ -705,9 +705,7 @@ def get_ids(details, label=None):
             pos = lab + 2
             if details[lab + 1].lower() == "atoms":
                 ids0, pos = _collect_atom_index_tokens(details, pos)
-                _require_atom_index_end(
-                    details, pos, {"point", "plane", "axis", "end"}
-                )
+                _require_atom_index_end(details, pos, {"point", "plane", "axis", "end"})
                 ids0 = _atom_indexes_to_cp2k_list(ids0)
             else:
                 while pos < len(details) and is_number(details[pos]):

--- a/aiida_nanotech_empa/workflows/cp2k/cp2k_utils.py
+++ b/aiida_nanotech_empa/workflows/cp2k/cp2k_utils.py
@@ -560,7 +560,7 @@ def string_range_to_list(strng, shift=-1):
             return [], False
 
         if ".." in item:
-            start, end = (int(value) for value in item.split(".."))
+            start, end = [int(value) for value in item.split("..")]
             if start > end:
                 return [], False
             indexes.extend(i + shift for i in range(start, end + 1))
@@ -705,7 +705,9 @@ def get_ids(details, label=None):
             pos = lab + 2
             if details[lab + 1].lower() == "atoms":
                 ids0, pos = _collect_atom_index_tokens(details, pos)
-                _require_atom_index_end(details, pos, {"point", "plane", "axis", "end"})
+                _require_atom_index_end(
+                    details, pos, {"point", "plane", "axis", "end"}
+                )
                 ids0 = _atom_indexes_to_cp2k_list(ids0)
             else:
                 while pos < len(details) and is_number(details[pos]):

--- a/aiida_nanotech_empa/workflows/qe/__init__.py
+++ b/aiida_nanotech_empa/workflows/qe/__init__.py
@@ -1,3 +1,4 @@
+from .banduppy import QeBanduppyUnfoldingWorkChain
 from .nanoribbon import NanoribbonWorkChain
 
-__all__ = ("NanoribbonWorkChain",)
+__all__ = ("NanoribbonWorkChain", "QeBanduppyUnfoldingWorkChain")

--- a/aiida_nanotech_empa/workflows/qe/banduppy.py
+++ b/aiida_nanotech_empa/workflows/qe/banduppy.py
@@ -5,7 +5,6 @@ import numpy as np
 from aiida import engine, orm, plugins
 from aiida.common import exceptions
 
-
 PwCalculation = plugins.CalculationFactory("quantumespresso.pw")
 QeBanduppyCalculation = plugins.CalculationFactory("nanotech_empa.qe_banduppy")
 
@@ -39,16 +38,32 @@ class QeBanduppyUnfoldingWorkChain(engine.WorkChain):
             cls.inspect_banduppy,
             cls.results,
         )
-        spec.output("folded_qe_remote_folder", valid_type=orm.RemoteData, required=False)
+        spec.output(
+            "folded_qe_remote_folder", valid_type=orm.RemoteData, required=False
+        )
         spec.output("folded_kpoints", valid_type=orm.KpointsData, required=False)
         spec.output("mapping_arrays", valid_type=orm.ArrayData, required=False)
         spec.output("mapping_data", valid_type=orm.Dict, required=False)
         spec.output("banduppy_retrieved", valid_type=orm.FolderData, required=False)
         spec.outputs.dynamic = True
-        spec.exit_code(300, "ERROR_TEMPLATE_REMOTE_EMPTY", message="The template QE remote folder is missing or empty.")
-        spec.exit_code(310, "ERROR_FOLDED_QE_FAILED", message="The folded-kpoints QE calculation failed.")
-        spec.exit_code(320, "ERROR_FOLDED_QE_REMOTE_EMPTY", message="The folded QE remote folder is missing or empty.")
-        spec.exit_code(330, "ERROR_BANDUPPY_FAILED", message="The BandUPpy calculation failed.")
+        spec.exit_code(
+            300,
+            "ERROR_TEMPLATE_REMOTE_EMPTY",
+            message="The template QE remote folder is missing or empty.",
+        )
+        spec.exit_code(
+            310,
+            "ERROR_FOLDED_QE_FAILED",
+            message="The folded-kpoints QE calculation failed.",
+        )
+        spec.exit_code(
+            320,
+            "ERROR_FOLDED_QE_REMOTE_EMPTY",
+            message="The folded QE remote folder is missing or empty.",
+        )
+        spec.exit_code(
+            330, "ERROR_BANDUPPY_FAILED", message="The BandUPpy calculation failed."
+        )
 
     def setup(self):
         self.ctx.unfolding_parameters = self.inputs.unfolding_parameters.get_dict()
@@ -102,7 +117,9 @@ class QeBanduppyUnfoldingWorkChain(engine.WorkChain):
 
         kpoints = orm.KpointsData()
         kpoints.set_cell_from_structure(self.inputs.structure)
-        kpoints.set_kpoints(kpoints_sbz[:, :3], cartesian=False, weights=np.ones(len(kpoints_sbz)))
+        kpoints.set_kpoints(
+            kpoints_sbz[:, :3], cartesian=False, weights=np.ones(len(kpoints_sbz))
+        )
         kpoints.label = "BandUPpy folded supercell k-points"
         kpoints.description = json.dumps(
             {
@@ -110,7 +127,9 @@ class QeBanduppyUnfoldingWorkChain(engine.WorkChain):
                 "supercell_matrix": matrix.tolist(),
                 "primitive_path": path,
                 "labels": labels,
-                "npoints_per_segment": list(npoints) if isinstance(npoints, tuple) else npoints,
+                "npoints_per_segment": (
+                    list(npoints) if isinstance(npoints, tuple) else npoints
+                ),
                 "kpoint_spacing": params.get("kpoint_spacing"),
             }
         )
@@ -122,7 +141,9 @@ class QeBanduppyUnfoldingWorkChain(engine.WorkChain):
         arrays.set_array("kpoints_sbz", np.asarray(kpoints_sbz))
         arrays.set_array(
             "primitive_kline",
-            _primitive_kline(self.inputs.structure, matrix, np.asarray(kpoints_pbz_full)[:, :3]),
+            _primitive_kline(
+                self.inputs.structure, matrix, np.asarray(kpoints_pbz_full)[:, :3]
+            ),
         )
         arrays.label = "BandUPpy QE unfolding k-point arrays"
         arrays.store()
@@ -130,7 +151,9 @@ class QeBanduppyUnfoldingWorkChain(engine.WorkChain):
         self.ctx.folded_kpoints = kpoints
         self.ctx.mapping_arrays = arrays
         self.ctx.mapping_data = orm.Dict(dict=_jsonable_mapping(mapping))
-        self.ctx.special_labels = orm.Dict(dict=_jsonable_special_labels(special_labels))
+        self.ctx.special_labels = orm.Dict(
+            dict=_jsonable_special_labels(special_labels)
+        )
         self.out("folded_kpoints", kpoints)
         self.out("mapping_arrays", arrays)
         self.out("mapping_data", self.ctx.mapping_data)
@@ -141,7 +164,9 @@ class QeBanduppyUnfoldingWorkChain(engine.WorkChain):
         builder.structure = self.inputs.structure
         builder.pseudos = dict(self.inputs.pseudos)
         builder.kpoints = self.ctx.folded_kpoints
-        builder.parameters = orm.Dict(dict=_folded_qe_parameters(self.inputs.parameters.get_dict()))
+        builder.parameters = orm.Dict(
+            dict=_folded_qe_parameters(self.inputs.parameters.get_dict())
+        )
         if "parent_folder" in self.inputs:
             builder.parent_folder = self.inputs.parent_folder
         if "settings" in self.inputs:
@@ -238,7 +263,9 @@ def _jsonable_special_labels(special_labels):
 
 def _primitive_kline(structure, supercell_matrix, fractional_kpoints):
     supercell_lattice = np.asarray(structure.cell, dtype=float)
-    primitive_lattice = np.linalg.solve(np.asarray(supercell_matrix, dtype=float), supercell_lattice)
+    primitive_lattice = np.linalg.solve(
+        np.asarray(supercell_matrix, dtype=float), supercell_lattice
+    )
     reciprocal_lattice = 2.0 * np.pi * np.linalg.inv(primitive_lattice).T
     cartesian_kpoints = np.asarray(fractional_kpoints, dtype=float) @ reciprocal_lattice
     if len(cartesian_kpoints) == 0:

--- a/aiida_nanotech_empa/workflows/qe/banduppy.py
+++ b/aiida_nanotech_empa/workflows/qe/banduppy.py
@@ -1,0 +1,254 @@
+import copy
+import json
+
+import numpy as np
+from aiida import engine, orm, plugins
+from aiida.common import exceptions
+
+
+PwCalculation = plugins.CalculationFactory("quantumespresso.pw")
+QeBanduppyCalculation = plugins.CalculationFactory("nanotech_empa.qe_banduppy")
+
+
+class QeBanduppyUnfoldingWorkChain(engine.WorkChain):
+    """Unfold QE supercell bands onto a primitive-cell path with BandUPpy."""
+
+    @classmethod
+    def define(cls, spec):
+        super().define(spec)
+        spec.input("pw_code", valid_type=orm.AbstractCode)
+        spec.input("banduppy_code", valid_type=orm.AbstractCode)
+        spec.input("structure", valid_type=orm.StructureData)
+        spec.input("parameters", valid_type=orm.Dict)
+        spec.input("parent_folder", valid_type=orm.RemoteData, required=False)
+        spec.input("template_remote_folder", valid_type=orm.RemoteData)
+        spec.input("template_metadata", valid_type=orm.Dict, required=False)
+        spec.input("unfolding_parameters", valid_type=orm.Dict)
+        spec.input_namespace("pseudos", valid_type=orm.Data, dynamic=True)
+        spec.input("settings", valid_type=orm.Dict, required=False)
+        spec.input("parallelization", valid_type=orm.Dict, required=False)
+        spec.input("pw_metadata_options", valid_type=orm.Dict, required=False)
+        spec.input("banduppy_metadata_options", valid_type=orm.Dict, required=False)
+        spec.outline(
+            cls.setup,
+            cls.inspect_template_remote,
+            cls.prepare_folded_kpoints,
+            cls.run_folded_qe,
+            cls.inspect_folded_qe,
+            cls.run_banduppy,
+            cls.inspect_banduppy,
+            cls.results,
+        )
+        spec.output("folded_qe_remote_folder", valid_type=orm.RemoteData, required=False)
+        spec.output("folded_kpoints", valid_type=orm.KpointsData, required=False)
+        spec.output("mapping_arrays", valid_type=orm.ArrayData, required=False)
+        spec.output("mapping_data", valid_type=orm.Dict, required=False)
+        spec.output("banduppy_retrieved", valid_type=orm.FolderData, required=False)
+        spec.outputs.dynamic = True
+        spec.exit_code(300, "ERROR_TEMPLATE_REMOTE_EMPTY", message="The template QE remote folder is missing or empty.")
+        spec.exit_code(310, "ERROR_FOLDED_QE_FAILED", message="The folded-kpoints QE calculation failed.")
+        spec.exit_code(320, "ERROR_FOLDED_QE_REMOTE_EMPTY", message="The folded QE remote folder is missing or empty.")
+        spec.exit_code(330, "ERROR_BANDUPPY_FAILED", message="The BandUPpy calculation failed.")
+
+    def setup(self):
+        self.ctx.unfolding_parameters = self.inputs.unfolding_parameters.get_dict()
+        self.ctx.template_metadata = (
+            self.inputs.template_metadata.get_dict()
+            if "template_metadata" in self.inputs
+            else {}
+        )
+        self.report(
+            "Starting QE BandUPpy unfolding"
+            + (
+                f" from template UUID {self.ctx.template_metadata.get('template_uuid')}"
+                if self.ctx.template_metadata.get("template_uuid")
+                else ""
+            )
+        )
+
+    def inspect_template_remote(self):
+        if not _remote_folder_has_entries(self.inputs.template_remote_folder):
+            return self.exit_codes.ERROR_TEMPLATE_REMOTE_EMPTY
+
+    def prepare_folded_kpoints(self):
+        import banduppy
+
+        params = self.ctx.unfolding_parameters
+        matrix = np.asarray(params["supercell_matrix"], dtype=int)
+        path = params["path"]
+        labels = params["labels"]
+        npoints = params.get("npoints_per_segment", 20)
+        if isinstance(npoints, (list, tuple)):
+            npoints = tuple(int(value) for value in npoints)
+        else:
+            npoints = int(npoints)
+
+        band_unfold = banduppy.Unfolding(supercell=matrix, print_log=None)
+        (
+            kpoints_pbz_full,
+            _kpoints_pbz_unique,
+            kpoints_sbz,
+            mapping,
+            special_labels,
+        ) = band_unfold.generate_SC_Kpts_from_pc_k_path(
+            pathPBZ=path,
+            nk=npoints,
+            labels=labels,
+            kpts_weights=1.0,
+            save_all_kpts=False,
+            save_sc_kpts=False,
+            file_format="qe",
+        )
+
+        kpoints = orm.KpointsData()
+        kpoints.set_cell_from_structure(self.inputs.structure)
+        kpoints.set_kpoints(kpoints_sbz[:, :3], cartesian=False, weights=np.ones(len(kpoints_sbz)))
+        kpoints.label = "BandUPpy folded supercell k-points"
+        kpoints.description = json.dumps(
+            {
+                "source": "BandUPpy",
+                "supercell_matrix": matrix.tolist(),
+                "primitive_path": path,
+                "labels": labels,
+                "npoints_per_segment": list(npoints) if isinstance(npoints, tuple) else npoints,
+                "kpoint_spacing": params.get("kpoint_spacing"),
+            }
+        )
+        kpoints.store()
+
+        arrays = orm.ArrayData()
+        arrays.set_array("supercell_matrix", matrix)
+        arrays.set_array("kpoints_pbz_full", np.asarray(kpoints_pbz_full))
+        arrays.set_array("kpoints_sbz", np.asarray(kpoints_sbz))
+        arrays.set_array(
+            "primitive_kline",
+            _primitive_kline(self.inputs.structure, matrix, np.asarray(kpoints_pbz_full)[:, :3]),
+        )
+        arrays.label = "BandUPpy QE unfolding k-point arrays"
+        arrays.store()
+
+        self.ctx.folded_kpoints = kpoints
+        self.ctx.mapping_arrays = arrays
+        self.ctx.mapping_data = orm.Dict(dict=_jsonable_mapping(mapping))
+        self.ctx.special_labels = orm.Dict(dict=_jsonable_special_labels(special_labels))
+        self.out("folded_kpoints", kpoints)
+        self.out("mapping_arrays", arrays)
+        self.out("mapping_data", self.ctx.mapping_data)
+
+    def run_folded_qe(self):
+        builder = PwCalculation.get_builder()
+        builder.code = self.inputs.pw_code
+        builder.structure = self.inputs.structure
+        builder.pseudos = dict(self.inputs.pseudos)
+        builder.kpoints = self.ctx.folded_kpoints
+        builder.parameters = orm.Dict(dict=_folded_qe_parameters(self.inputs.parameters.get_dict()))
+        if "parent_folder" in self.inputs:
+            builder.parent_folder = self.inputs.parent_folder
+        if "settings" in self.inputs:
+            builder.settings = self.inputs.settings
+        if "parallelization" in self.inputs:
+            builder.parallelization = self.inputs.parallelization
+        if "pw_metadata_options" in self.inputs:
+            builder.metadata.options = self.inputs.pw_metadata_options.get_dict()
+        builder.metadata.label = "BandUPpy folded-kpoints QE bands"
+        builder.metadata.description = (
+            "QE bands calculation on folded supercell k-points for BandUPpy unfolding."
+        )
+        self.report("Submitting folded-kpoints QE calculation")
+        return engine.ToContext(folded_qe=self.submit(builder))
+
+    def inspect_folded_qe(self):
+        calc = self.ctx.folded_qe
+        if not calc.is_finished_ok:
+            return self.exit_codes.ERROR_FOLDED_QE_FAILED
+        self.out("folded_qe_remote_folder", calc.outputs.remote_folder)
+        if not _remote_folder_has_entries(calc.outputs.remote_folder):
+            return self.exit_codes.ERROR_FOLDED_QE_REMOTE_EMPTY
+
+    def run_banduppy(self):
+        calc = self.ctx.folded_qe
+        control = calc.inputs.parameters.get_dict().get("CONTROL", {})
+        outputs = _created_outputs(calc)
+        output_parameters = outputs.get("output_parameters")
+        fermi_energy = None
+        if output_parameters is not None:
+            fermi_energy = output_parameters.get_dict().get("fermi_energy")
+        params = copy.deepcopy(self.ctx.unfolding_parameters)
+        params.update(
+            {
+                "prefix": control.get("prefix", "aiida"),
+                "outdir": control.get("outdir", "./out/"),
+                "fermi_energy": fermi_energy,
+            }
+        )
+
+        builder = QeBanduppyCalculation.get_builder()
+        builder.code = self.inputs.banduppy_code
+        builder.folded_qe_remote_folder = calc.outputs.remote_folder
+        builder.parameters = orm.Dict(dict=params)
+        builder.mapping_arrays = self.ctx.mapping_arrays
+        builder.mapping_data = self.ctx.mapping_data
+        builder.special_labels = self.ctx.special_labels
+        if "banduppy_metadata_options" in self.inputs:
+            builder.metadata.options = self.inputs.banduppy_metadata_options.get_dict()
+        builder.metadata.label = "QE BandUPpy unfolding"
+        builder.metadata.description = (
+            "BandUPpy unfolding of a QE folded-kpoints bands calculation."
+        )
+        self.report("Submitting BandUPpy unfolding calculation")
+        return engine.ToContext(banduppy=self.submit(builder))
+
+    def inspect_banduppy(self):
+        if not self.ctx.banduppy.is_finished_ok:
+            return self.exit_codes.ERROR_BANDUPPY_FAILED
+
+    def results(self):
+        self.out("banduppy_retrieved", self.ctx.banduppy.outputs.retrieved)
+
+
+def _folded_qe_parameters(parameters):
+    result = copy.deepcopy(parameters)
+    result.setdefault("CONTROL", {})
+    result["CONTROL"]["calculation"] = "bands"
+    return result
+
+
+def _remote_folder_has_entries(remote_folder):
+    try:
+        with remote_folder.computer.get_transport() as transport:
+            path = remote_folder.get_remote_path()
+            return transport.isdir(path) and bool(transport.listdir(path))
+    except exceptions.TransportTaskException:
+        return False
+
+
+def _jsonable_mapping(mapping):
+    return {
+        str(int(k_index)): {
+            str(int(unique_index)): [int(item) for item in k_indices]
+            for unique_index, k_indices in unique_map.items()
+        }
+        for k_index, unique_map in mapping.items()
+    }
+
+
+def _jsonable_special_labels(special_labels):
+    return {str(key): str(value) for key, value in dict(special_labels).items()}
+
+
+def _primitive_kline(structure, supercell_matrix, fractional_kpoints):
+    supercell_lattice = np.asarray(structure.cell, dtype=float)
+    primitive_lattice = np.linalg.solve(np.asarray(supercell_matrix, dtype=float), supercell_lattice)
+    reciprocal_lattice = 2.0 * np.pi * np.linalg.inv(primitive_lattice).T
+    cartesian_kpoints = np.asarray(fractional_kpoints, dtype=float) @ reciprocal_lattice
+    if len(cartesian_kpoints) == 0:
+        return np.array([], dtype=float)
+    distances = np.linalg.norm(np.diff(cartesian_kpoints, axis=0), axis=1)
+    return np.concatenate(([0.0], np.cumsum(distances)))
+
+
+def _created_outputs(calc):
+    return {
+        triple.link_label: triple.node
+        for triple in calc.base.links.get_outgoing().all()
+    }

--- a/aiida_nanotech_empa/workflows/qe/banduppy.py
+++ b/aiida_nanotech_empa/workflows/qe/banduppy.py
@@ -4,6 +4,7 @@ import json
 import numpy as np
 from aiida import engine, orm, plugins
 from aiida.common import exceptions
+from aiida.common.links import LinkType
 
 PwCalculation = plugins.CalculationFactory("quantumespresso.pw")
 QeBanduppyCalculation = plugins.CalculationFactory("nanotech_empa.qe_banduppy")
@@ -23,15 +24,29 @@ class QeBanduppyUnfoldingWorkChain(engine.WorkChain):
         spec.input("template_remote_folder", valid_type=orm.RemoteData)
         spec.input("template_metadata", valid_type=orm.Dict, required=False)
         spec.input("unfolding_parameters", valid_type=orm.Dict)
+        spec.input(
+            "run_reference_bands",
+            valid_type=orm.Bool,
+            default=lambda: orm.Bool(True),
+            required=False,
+        )
         spec.input_namespace("pseudos", valid_type=orm.Data, dynamic=True)
         spec.input("settings", valid_type=orm.Dict, required=False)
         spec.input("parallelization", valid_type=orm.Dict, required=False)
         spec.input("pw_metadata_options", valid_type=orm.Dict, required=False)
+        spec.input("reference_pw_metadata_options", valid_type=orm.Dict, required=False)
         spec.input("banduppy_metadata_options", valid_type=orm.Dict, required=False)
         spec.outline(
             cls.setup,
             cls.inspect_template_remote,
             cls.prepare_folded_kpoints,
+            engine.if_(cls.should_run_reference)(
+                cls.prepare_reference_inputs,
+                cls.run_reference_scf,
+                cls.inspect_reference_scf,
+                cls.run_reference_bands,
+                cls.inspect_reference_bands,
+            ),
             cls.run_folded_qe,
             cls.inspect_folded_qe,
             cls.run_banduppy,
@@ -42,6 +57,17 @@ class QeBanduppyUnfoldingWorkChain(engine.WorkChain):
             "folded_qe_remote_folder", valid_type=orm.RemoteData, required=False
         )
         spec.output("folded_kpoints", valid_type=orm.KpointsData, required=False)
+        spec.output("reference_structure", valid_type=orm.StructureData, required=False)
+        spec.output("reference_scf_kpoints", valid_type=orm.KpointsData, required=False)
+        spec.output("reference_kpoints", valid_type=orm.KpointsData, required=False)
+        spec.output(
+            "reference_scf_remote_folder", valid_type=orm.RemoteData, required=False
+        )
+        spec.output(
+            "reference_bands_remote_folder", valid_type=orm.RemoteData, required=False
+        )
+        spec.output("reference_bands", valid_type=orm.BandsData, required=False)
+        spec.output("reference_bands_parameters", valid_type=orm.Dict, required=False)
         spec.output("mapping_arrays", valid_type=orm.ArrayData, required=False)
         spec.output("mapping_data", valid_type=orm.Dict, required=False)
         spec.output("banduppy_retrieved", valid_type=orm.FolderData, required=False)
@@ -57,12 +83,27 @@ class QeBanduppyUnfoldingWorkChain(engine.WorkChain):
             message="The folded-kpoints QE calculation failed.",
         )
         spec.exit_code(
+            315,
+            "ERROR_REFERENCE_SCF_FAILED",
+            message="The primitive reference SCF calculation failed.",
+        )
+        spec.exit_code(
+            316,
+            "ERROR_REFERENCE_BANDS_FAILED",
+            message="The primitive reference bands calculation failed.",
+        )
+        spec.exit_code(
             320,
             "ERROR_FOLDED_QE_REMOTE_EMPTY",
             message="The folded QE remote folder is missing or empty.",
         )
         spec.exit_code(
             330, "ERROR_BANDUPPY_FAILED", message="The BandUPpy calculation failed."
+        )
+        spec.exit_code(
+            340,
+            "ERROR_BANDUPPY_OUTPUT_MISSING",
+            message="The BandUPpy calculation did not retrieve unfolding_bands.npz.",
         )
 
     def setup(self):
@@ -84,6 +125,9 @@ class QeBanduppyUnfoldingWorkChain(engine.WorkChain):
     def inspect_template_remote(self):
         if not _remote_folder_has_entries(self.inputs.template_remote_folder):
             return self.exit_codes.ERROR_TEMPLATE_REMOTE_EMPTY
+
+    def should_run_reference(self):
+        return bool(self.inputs.run_reference_bands.value)
 
     def prepare_folded_kpoints(self):
         import banduppy
@@ -158,6 +202,129 @@ class QeBanduppyUnfoldingWorkChain(engine.WorkChain):
         self.out("mapping_arrays", arrays)
         self.out("mapping_data", self.ctx.mapping_data)
 
+    def prepare_reference_inputs(self):
+        params = self.ctx.unfolding_parameters
+        matrix = np.asarray(params["supercell_matrix"], dtype=int)
+        tolerance = float(params.get("primitive_atom_tolerance", 0.08))
+        reference_structure = _build_reference_primitive_structure(
+            self.inputs.structure, matrix, tolerance=tolerance
+        )
+        reference_structure.label = "BandUPpy pristine primitive reference structure"
+        reference_structure.store()
+
+        reference_scf_kpoints = _reference_scf_kpoints(
+            self.inputs.structure,
+            reference_structure,
+            matrix,
+            self.inputs.parent_folder if "parent_folder" in self.inputs else None,
+        )
+        reference_scf_kpoints.store()
+
+        reference_kpoints = orm.KpointsData()
+        reference_kpoints.set_cell_from_structure(reference_structure)
+        reference_kpoints.set_kpoints(
+            self.ctx.mapping_arrays.get_array("kpoints_pbz_full")[:, :3],
+            cartesian=False,
+            weights=np.ones(len(self.ctx.mapping_arrays.get_array("kpoints_pbz_full"))),
+        )
+        try:
+            reference_kpoints.labels = _deduplicated_kpoint_labels(
+                self.ctx.special_labels.get_dict(),
+                self.ctx.mapping_arrays.get_array("kpoints_pbz_full")[:, :3],
+            )
+        except Exception:
+            pass
+        reference_kpoints.label = "BandUPpy primitive reference k-points"
+        reference_kpoints.store()
+
+        self.ctx.reference_structure = reference_structure
+        self.ctx.reference_scf_kpoints = reference_scf_kpoints
+        self.ctx.reference_kpoints = reference_kpoints
+        self.out("reference_structure", reference_structure)
+        self.out("reference_scf_kpoints", reference_scf_kpoints)
+        self.out("reference_kpoints", reference_kpoints)
+
+    def run_reference_scf(self):
+        matrix = np.asarray(
+            self.ctx.unfolding_parameters["supercell_matrix"], dtype=int
+        )
+        builder = PwCalculation.get_builder()
+        builder.code = self.inputs.pw_code
+        builder.structure = self.ctx.reference_structure
+        builder.pseudos = _filter_pseudos_for_structure(
+            dict(self.inputs.pseudos), self.ctx.reference_structure
+        )
+        builder.kpoints = self.ctx.reference_scf_kpoints
+        builder.parameters = orm.Dict(
+            dict=_reference_qe_parameters(
+                self.inputs.parameters.get_dict(), matrix, calculation="scf"
+            )
+        )
+        if "settings" in self.inputs:
+            builder.settings = self.inputs.settings
+        if "parallelization" in self.inputs:
+            builder.parallelization = self.inputs.parallelization
+        if "reference_pw_metadata_options" in self.inputs:
+            builder.metadata.options = (
+                self.inputs.reference_pw_metadata_options.get_dict()
+            )
+        elif "pw_metadata_options" in self.inputs:
+            builder.metadata.options = self.inputs.pw_metadata_options.get_dict()
+        builder.metadata.label = "BandUPpy pristine primitive reference SCF"
+        builder.metadata.description = (
+            "SCF calculation for the ideal primitive-cell reference bandstructure."
+        )
+        self.report("Submitting primitive reference SCF calculation")
+        return engine.ToContext(reference_scf=self.submit(builder))
+
+    def inspect_reference_scf(self):
+        calc = self.ctx.reference_scf
+        if not calc.is_finished_ok:
+            return self.exit_codes.ERROR_REFERENCE_SCF_FAILED
+        self.out("reference_scf_remote_folder", calc.outputs.remote_folder)
+
+    def run_reference_bands(self):
+        matrix = np.asarray(
+            self.ctx.unfolding_parameters["supercell_matrix"], dtype=int
+        )
+        builder = PwCalculation.get_builder()
+        builder.code = self.inputs.pw_code
+        builder.structure = self.ctx.reference_structure
+        builder.pseudos = _filter_pseudos_for_structure(
+            dict(self.inputs.pseudos), self.ctx.reference_structure
+        )
+        builder.kpoints = self.ctx.reference_kpoints
+        builder.parameters = orm.Dict(
+            dict=_reference_qe_parameters(
+                self.inputs.parameters.get_dict(), matrix, calculation="bands"
+            )
+        )
+        builder.parent_folder = self.ctx.reference_scf.outputs.remote_folder
+        if "settings" in self.inputs:
+            builder.settings = self.inputs.settings
+        if "parallelization" in self.inputs:
+            builder.parallelization = self.inputs.parallelization
+        if "reference_pw_metadata_options" in self.inputs:
+            builder.metadata.options = (
+                self.inputs.reference_pw_metadata_options.get_dict()
+            )
+        elif "pw_metadata_options" in self.inputs:
+            builder.metadata.options = self.inputs.pw_metadata_options.get_dict()
+        builder.metadata.label = "BandUPpy pristine primitive reference bands"
+        builder.metadata.description = (
+            "QE bands calculation for the ideal primitive-cell reference path."
+        )
+        self.report("Submitting primitive reference bands calculation")
+        return engine.ToContext(reference_bands_calc=self.submit(builder))
+
+    def inspect_reference_bands(self):
+        calc = self.ctx.reference_bands_calc
+        if not calc.is_finished_ok:
+            return self.exit_codes.ERROR_REFERENCE_BANDS_FAILED
+        self.out("reference_bands_remote_folder", calc.outputs.remote_folder)
+        self.out("reference_bands", calc.outputs.output_band)
+        self.out("reference_bands_parameters", calc.outputs.output_parameters)
+
     def run_folded_qe(self):
         builder = PwCalculation.get_builder()
         builder.code = self.inputs.pw_code
@@ -165,7 +332,9 @@ class QeBanduppyUnfoldingWorkChain(engine.WorkChain):
         builder.pseudos = dict(self.inputs.pseudos)
         builder.kpoints = self.ctx.folded_kpoints
         builder.parameters = orm.Dict(
-            dict=_folded_qe_parameters(self.inputs.parameters.get_dict())
+            dict=_folded_qe_parameters(
+                self.inputs.parameters.get_dict(), self.ctx.unfolding_parameters
+            )
         )
         if "parent_folder" in self.inputs:
             builder.parent_folder = self.inputs.parent_folder
@@ -199,6 +368,7 @@ class QeBanduppyUnfoldingWorkChain(engine.WorkChain):
         if output_parameters is not None:
             fermi_energy = output_parameters.get_dict().get("fermi_energy")
         params = copy.deepcopy(self.ctx.unfolding_parameters)
+        params.setdefault("kpoint_batch_size", 1)
         params.update(
             {
                 "prefix": control.get("prefix", "aiida"),
@@ -226,16 +396,211 @@ class QeBanduppyUnfoldingWorkChain(engine.WorkChain):
     def inspect_banduppy(self):
         if not self.ctx.banduppy.is_finished_ok:
             return self.exit_codes.ERROR_BANDUPPY_FAILED
+        retrieved = self.ctx.banduppy.outputs.retrieved
+        if "unfolding_bands.npz" not in retrieved.base.repository.list_object_names():
+            self.report("BandUPpy output unfolding_bands.npz was not retrieved")
+            return self.exit_codes.ERROR_BANDUPPY_OUTPUT_MISSING
 
     def results(self):
         self.out("banduppy_retrieved", self.ctx.banduppy.outputs.retrieved)
 
 
-def _folded_qe_parameters(parameters):
+def _folded_qe_parameters(parameters, unfolding_parameters=None):
     result = copy.deepcopy(parameters)
     result.setdefault("CONTROL", {})
     result["CONTROL"]["calculation"] = "bands"
+    diagonalization = (unfolding_parameters or {}).get("folded_diagonalization")
+    if diagonalization and diagonalization != "inherit":
+        result.setdefault("ELECTRONS", {})["diagonalization"] = str(diagonalization)
     return result
+
+
+def _reference_qe_parameters(parameters, supercell_matrix, *, calculation):
+    result = copy.deepcopy(parameters)
+    result.setdefault("CONTROL", {})
+    result.setdefault("SYSTEM", {})
+    result.setdefault("ELECTRONS", {})
+    result["CONTROL"]["calculation"] = calculation
+    result["CONTROL"]["restart_mode"] = "from_scratch"
+
+    system = result["SYSTEM"]
+    original_nbnd = system.get("nbnd")
+    for key in (
+        "tot_charge",
+        "nspin",
+        "starting_magnetization",
+        "tot_magnetization",
+        "constrained_magnetization",
+    ):
+        system.pop(key, None)
+    for key in list(system):
+        if str(key).startswith("starting_ns_eigenvalue"):
+            system.pop(key, None)
+
+    det = max(1, int(round(abs(float(np.linalg.det(supercell_matrix))))))
+    if original_nbnd is not None and calculation == "bands":
+        system["nbnd"] = max(1, int(np.ceil(float(original_nbnd) / det)))
+    else:
+        system.pop("nbnd", None)
+
+    if calculation == "scf":
+        for key in ("startingpot", "startingwfc", "diago_full_acc"):
+            result["ELECTRONS"].pop(key, None)
+    return result
+
+
+def _filter_pseudos_for_structure(pseudos, structure):
+    missing = [kind.name for kind in structure.kinds if kind.name not in pseudos]
+    if missing:
+        raise ValueError(
+            f"No pseudo was provided for primitive reference kinds: {missing}"
+        )
+    return {kind.name: pseudos[kind.name] for kind in structure.kinds}
+
+
+def _build_reference_primitive_structure(structure, supercell_matrix, *, tolerance):
+    supercell_matrix = np.asarray(supercell_matrix, dtype=float)
+    supercell_cell = np.asarray(structure.cell, dtype=float)
+    primitive_cell = np.linalg.solve(supercell_matrix, supercell_cell)
+    kind_by_name = {kind.name: kind for kind in structure.kinds}
+    clusters = []
+    for site in structure.sites:
+        frac_sc = np.asarray(site.position, dtype=float) @ np.linalg.inv(supercell_cell)
+        frac_primitive = np.mod(frac_sc @ supercell_matrix, 1.0)
+        assigned = False
+        for cluster in clusters:
+            if (
+                _periodic_fractional_distance(frac_primitive, cluster["center"])
+                <= tolerance
+            ):
+                cluster["items"].append((frac_primitive, site.kind_name))
+                cluster["center"] = _periodic_mean(
+                    [item[0] for item in cluster["items"]]
+                )
+                assigned = True
+                break
+        if not assigned:
+            clusters.append(
+                {"center": frac_primitive, "items": [(frac_primitive, site.kind_name)]}
+            )
+
+    reference = orm.StructureData(cell=primitive_cell, pbc=structure.pbc)
+    metadata = []
+    for cluster in sorted(
+        clusters, key=lambda item: tuple(np.round(item["center"], 10))
+    ):
+        kind_counts = {}
+        for _, kind_name in cluster["items"]:
+            kind_counts[kind_name] = kind_counts.get(kind_name, 0) + 1
+        majority_kind = sorted(
+            kind_counts.items(), key=lambda item: (-item[1], item[0])
+        )[0][0]
+        majority_positions = [
+            frac for frac, kind_name in cluster["items"] if kind_name == majority_kind
+        ]
+        frac = _periodic_mean(majority_positions)
+        kind = kind_by_name[majority_kind]
+        symbols = kind.symbols[0] if len(kind.symbols) == 1 else kind.symbols
+        reference.append_atom(
+            position=np.asarray(frac, dtype=float) @ primitive_cell,
+            symbols=symbols,
+            name=kind.name,
+        )
+        metadata.append(
+            {
+                "kind": majority_kind,
+                "counts": kind_counts,
+                "fractional_position": [float(value) for value in frac],
+            }
+        )
+    reference.description = json.dumps(
+        {
+            "source": "clustered from defective supercell",
+            "supercell_matrix": np.asarray(supercell_matrix, dtype=int).tolist(),
+            "primitive_atom_tolerance": float(tolerance),
+            "clusters": metadata,
+        }
+    )
+    return reference
+
+
+def _periodic_fractional_distance(left, right):
+    delta = np.asarray(left, dtype=float) - np.asarray(right, dtype=float)
+    delta -= np.rint(delta)
+    return float(np.linalg.norm(delta))
+
+
+def _periodic_mean(points):
+    points = np.asarray(points, dtype=float)
+    result = []
+    for axis in range(points.shape[1]):
+        angles = 2.0 * np.pi * points[:, axis]
+        mean_angle = np.arctan2(np.mean(np.sin(angles)), np.mean(np.cos(angles)))
+        result.append((mean_angle / (2.0 * np.pi)) % 1.0)
+    return np.asarray(result, dtype=float)
+
+
+def _reference_scf_kpoints(
+    supercell_structure, reference_structure, supercell_matrix, parent_folder
+):
+    mesh = np.ones(3, dtype=int)
+    offset = [0.0, 0.0, 0.0]
+    if parent_folder is not None:
+        creator = _created_by(parent_folder)
+        if creator is not None and "kpoints" in creator.inputs:
+            try:
+                mesh, offset = creator.inputs.kpoints.get_kpoints_mesh()
+                mesh = np.asarray(mesh, dtype=int)
+            except Exception:
+                mesh = np.ones(3, dtype=int)
+    factors = np.maximum(
+        1,
+        np.rint(
+            np.linalg.norm(np.asarray(supercell_matrix, dtype=float), axis=0)
+        ).astype(int),
+    )
+    primitive_mesh = np.maximum(1, mesh * factors)
+    primitive_mesh = [
+        int(value) if pbc else 1
+        for value, pbc in zip(primitive_mesh, reference_structure.pbc)
+    ]
+    kpoints = orm.KpointsData()
+    kpoints.set_cell_from_structure(reference_structure)
+    kpoints.set_kpoints_mesh(primitive_mesh, offset=offset)
+    kpoints.label = "BandUPpy primitive reference SCF k-points"
+    kpoints.description = json.dumps(
+        {
+            "source_supercell_mesh": [int(value) for value in mesh],
+            "supercell_matrix_factors": [int(value) for value in factors],
+        }
+    )
+    return kpoints
+
+
+def _created_by(data_node):
+    incoming = data_node.base.links.get_incoming(link_type=LinkType.CREATE).all()
+    return incoming[0].node if incoming else None
+
+
+def _deduplicated_kpoint_labels(special_labels, kpoints):
+    labels = []
+    previous_label = None
+    previous_point = None
+    for index_text, label in sorted(
+        special_labels.items(), key=lambda item: int(item[0])
+    ):
+        index = int(index_text)
+        point = np.asarray(kpoints[index], dtype=float)
+        if (
+            previous_label == label
+            and previous_point is not None
+            and np.allclose(point, previous_point)
+        ):
+            continue
+        labels.append((index, str(label)))
+        previous_label = label
+        previous_point = point
+    return labels
 
 
 def _remote_folder_has_entries(remote_folder):

--- a/conftest.py
+++ b/conftest.py
@@ -129,7 +129,9 @@ def cp2k_code(local_code_factory):
 
 @pytest.fixture(scope="function")
 def spm_code(local_code_factory):
-    return local_code_factory("nanotech_empa.stm", "cp2k-stm-sts-wfn", label="stm")
+    return local_code_factory(
+        "nanotech_empa.stm", "cp2k-stm-sts-wfn", label="stm"
+    )
 
 
 @pytest.fixture(scope="function")

--- a/conftest.py
+++ b/conftest.py
@@ -129,9 +129,7 @@ def cp2k_code(local_code_factory):
 
 @pytest.fixture(scope="function")
 def spm_code(local_code_factory):
-    return local_code_factory(
-        "nanotech_empa.stm", "cp2k-stm-sts-wfn", label="stm"
-    )
+    return local_code_factory("nanotech_empa.stm", "cp2k-stm-sts-wfn", label="stm")
 
 
 @pytest.fixture(scope="function")

--- a/examples/workflows/example_cp2k_hrstm.py
+++ b/examples/workflows/example_cp2k_hrstm.py
@@ -1,4 +1,5 @@
 import os
+
 import ase.io
 import click
 import numpy as np

--- a/examples/workflows/example_cp2k_hrstm.py
+++ b/examples/workflows/example_cp2k_hrstm.py
@@ -1,5 +1,4 @@
 import os
-
 import ase.io
 import click
 import numpy as np

--- a/examples/workflows/example_cp2k_mol_opt_gw.py
+++ b/examples/workflows/example_cp2k_mol_opt_gw.py
@@ -53,7 +53,8 @@ def _geo_opt_cp2k_builder(cp2k_code):
     )
 
     data_dir = (
-        pathlib.Path(__file__).parents[2] / "aiida_nanotech_empa/workflows/cp2k/data"
+        pathlib.Path(__file__).parents[2]
+        / "aiida_nanotech_empa/workflows/cp2k/data"
     )
 
     builder = Cp2kCalculation.get_builder()

--- a/examples/workflows/example_cp2k_mol_opt_gw.py
+++ b/examples/workflows/example_cp2k_mol_opt_gw.py
@@ -53,8 +53,7 @@ def _geo_opt_cp2k_builder(cp2k_code):
     )
 
     data_dir = (
-        pathlib.Path(__file__).parents[2]
-        / "aiida_nanotech_empa/workflows/cp2k/data"
+        pathlib.Path(__file__).parents[2] / "aiida_nanotech_empa/workflows/cp2k/data"
     )
 
     builder = Cp2kCalculation.get_builder()

--- a/examples/workflows/example_cp2k_neb.py
+++ b/examples/workflows/example_cp2k_neb.py
@@ -12,9 +12,7 @@ Cp2kNebWorkChain = plugins.WorkflowFactory("nanotech_empa.cp2k.neb")
 DATA_DIR = script_dir(__file__)
 
 
-def _example_cp2k_neb(
-    cp2k_code, uks, restart_uuid, n_nodes=1, n_cores_per_node=1
-):
+def _example_cp2k_neb(cp2k_code, uks, restart_uuid, n_nodes=1, n_cores_per_node=1):
     builder = Cp2kNebWorkChain.get_builder()
 
     builder.metadata.label = "CP2K_NEB"

--- a/examples/workflows/example_cp2k_neb.py
+++ b/examples/workflows/example_cp2k_neb.py
@@ -12,7 +12,9 @@ Cp2kNebWorkChain = plugins.WorkflowFactory("nanotech_empa.cp2k.neb")
 DATA_DIR = script_dir(__file__)
 
 
-def _example_cp2k_neb(cp2k_code, uks, restart_uuid, n_nodes=1, n_cores_per_node=1):
+def _example_cp2k_neb(
+    cp2k_code, uks, restart_uuid, n_nodes=1, n_cores_per_node=1
+):
     builder = Cp2kNebWorkChain.get_builder()
 
     builder.metadata.label = "CP2K_NEB"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,12 +19,13 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "aiida-core>=2.8,<3.0.0",
-    "aiida-quantumespresso~=4.8",
+    "aiida-quantumespresso>=4.17,<5",
     "aiida-pseudo~=1.7",
     "aiida-cp2k>=2.1.1,<3.0.0",
     "ase~=3.21",
@@ -57,12 +58,14 @@ dev = [
 [project.entry-points."aiida.calculations"]
 "nanotech_empa.stm" = "aiida_nanotech_empa.plugins:StmCalculation"
 "nanotech_empa.overlap" = "aiida_nanotech_empa.plugins:OverlapCalculation"
+"nanotech_empa.qe_banduppy" = "aiida_nanotech_empa.plugins:QeBanduppyCalculation"
 "nanotech_empa.afm" = "aiida_nanotech_empa.plugins:AfmCalculation"
 "nanotech_empa.hrstm" = "aiida_nanotech_empa.plugins:HrstmCalculation"
 "nanotech_empa.cubehandler" = "aiida_nanotech_empa.plugins:CubeHandlerCalculation"
 
 [project.entry-points."aiida.workflows"]
 "nanotech_empa.nanoribbon" = "aiida_nanotech_empa.workflows.qe:NanoribbonWorkChain"
+"nanotech_empa.qe.banduppy_unfolding" = "aiida_nanotech_empa.workflows.qe:QeBanduppyUnfoldingWorkChain"
 "nanotech_empa.gaussian.scf" = "aiida_nanotech_empa.workflows.gaussian:GaussianScfWorkChain"
 "nanotech_empa.gaussian.relax" = "aiida_nanotech_empa.workflows.gaussian:GaussianRelaxWorkChain"
 "nanotech_empa.gaussian.delta_scf" = "aiida_nanotech_empa.workflows.gaussian:GaussianDeltaScfWorkChain"


### PR DESCRIPTION
## Summary

- Add the provenance-aware QE BandUPpy CalcJob and unfolding WorkChain.
- Add pristine primitive-cell SCF/bands references, spin support, folded-band controls, band selection, and batched unfolding.
- Retrieve the complete plotting dataset used by the companion AiiDAlab viewer.

Companion app: nanotech-empa/aiidalab-empa-qe-postprocess#1.

## Validation

- Local AiiDAlab smoke test completed on a 6x6 silicon defect workflow, including reference, folded QE, and BandUPpy steps.
- `ruff`, `py_compile`, Black, isort, autoflake, pyupgrade, mypy, AiiDA entry-point loading, and generated-runner compilation pass.
- Python 3.12.11, AiiDA 2.8.0, BandUPpy 0.3.4; `pip check` passes.

The isolated local Flake8 hook could not start because its plugin environment lacks `pkg_resources`; GitHub checks remain authoritative.

Prepared with Codex assistance.
